### PR TITLE
Fix bug where more than one reef was being used to calculate cost

### DIFF
--- a/docs/source/cost_models.rst
+++ b/docs/source/cost_models.rst
@@ -3,7 +3,7 @@ Cost Models
 
 The cost modelling used to calculate intervention costs are Excel-based models developed by the RRAP Translation to
 Deployment team. The models to sample need to be downloaded and added to the `cost_models` folder to be accessible by
-the functions in this library. They also require two key configuration files to be placed in the `src`` folder.
+the functions in this library. They also require two key configuration files to be placed in the `src` folder.
 
 The file 'config.csv' is a configuration file for sampling the cost model parameters and describes the
 names, excel spreadsheet positions and ranges of parameters to sample from the cost models. An example of
@@ -15,10 +15,10 @@ this file is below:
 A full example of the 'config.csv' file is available in the examples folder. At minimum,
 the file must include the following columns:
 
-* `cost_type`` : the model type the parameter belows to (currently either `production` or `deployment`).
-* `sheet`` : the sheet name the parameter occurs on.
+* `cost_type` : the model type the parameter belows to (currently either `production` or `deployment`).
+* `sheet` : the sheet name the parameter occurs on.
 * `factor_names`` : a label for the factor.
-* `cell_row`, `cell_col``: the cell row and column reference for the parameter.
+* `cell_row`, `cell_col`: the cell row and column reference for the parameter.
 * `range_lower`, `range_upper` : the upper and lower bounds for sampling the parameter.
 * `is_cat` : a flag designating whether the parameter is categorical or not.
 

--- a/docs/source/example_workflow.rst
+++ b/docs/source/example_workflow.rst
@@ -31,9 +31,6 @@ number of corals in each taxa and sizeclass in the rme resultset, but will be in
 Metric functions to include can be added using the optional parameter `metrics = [area_saved_above_thresh, area_weighted_rci]`.
 The defaults include area saved in and above good condition and area weighted RCI.
 
-The other optional parameter `max_dist` specifies how far apart reeks can be, in km, before a ship should return to
-port rather than travel to the reef in one trip.
-
 .. code-block:: python
 
     # Filepath to RME runs to process
@@ -42,7 +39,7 @@ port rather than travel to the reef in one trip.
     nsims = 3
     # Create metric datafiles for economics modelling and extract filename for intervention key
     int_keys_fn = prd.create_economics_metric_files(rme_files_path, nsims, ecol_uncert=1, shelt_uncert=0, expert_uncert=1,
-                                  metrics = [area_saved_above_thresh, area_weighted_rci], max_dist = 25.0,)
+                                  metrics = [area_saved_above_thresh, area_weighted_rci])
 
 
 After creating the metric summary files for CREAM, the cost files can be created by sampling the cost models

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -214,7 +214,7 @@ def calculate_costs(ID_key, n_draws, deploy_model_filepath=config["deploy_model_
                         factors_df_dep["Cost"] = save_cost_dep
 
                 # Calculate all cost codes and add to dataframe
-                cost_df.loc[cost_df.year==int_yr,cost_df.columns[rep*N+2:rep*N+N+2]] = cost_types(factors_df_dep[["Cost","setupCost"]]+factors_df_prod[["Cost","setupCost"]], cont_p, N)
+                cost_df.loc[cost_df.year==int_yr, cost_df.columns[rep*N+2:rep*N+N+2]] = cost_types(factors_df_dep[["Cost","setupCost"]] + factors_df_prod[["Cost","setupCost"]], cont_p, N)
 
                 # Drop cost columns
                 factors_df_dep = factors_df_dep.drop(columns=["Cost","setupCost"])


### PR DESCRIPTION
Previously, the ID key was being saved for each intervention reef, rather than for a representative reef which is the furthest from port. This PR fixes this issue and only saves this representative reef to be used in the cost modelling.