### PR TITLE
Fix cost model sampling 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ src/econ_outputs/*
 src/cost_outputs/*
 src/cost_models/*
 src/intervention_keys/*
+
+# Ignore config containing path to cost models
+src/config.json

--- a/docs/source/example_workflow.rst
+++ b/docs/source/example_workflow.rst
@@ -16,8 +16,9 @@ The following modules are first imported:
 The key metrics summary files for each intervention/counterfactual run can then be generated using
 `prd.create_economics_metric_files()`. This can be run with default parameters with just the filepath
 to the rme results and number of simulations, or with more detail specifications on types of uncertainty
-to sample and which metrics to calculate. The number of simulations `nsims` includes sampling the types
-of uncertainty specified by the uncertainty flags `ecol_uncert`, `shelt_uncert` and `expert_uncert`.
+to sample and which metrics to calculate. The total number of simulations `nsims` includes sampling the types
+of uncertainty specified by the uncertainty flags `ecol_uncert`, `shelt_uncert` and `expert_uncert`,
+and the same number of samples will be drawn from the cost modelling.
 
 If `ecol_uncert=1`, ecological uncertainty is sampled in the results by sampling rme reps for a particular
 set of results (stochastic samples within a single climate model). If `ecol_uncert=0` the mean over all
@@ -36,10 +37,10 @@ The defaults include area saved in and above good condition and area weighted RC
     # Filepath to RME runs to process
     rme_files_path = "path to ReefModEngine.jl results"
     # Number of sims for metrics sampling (default includes ecological and expert uncertainty in RCI calcs)
-    nsims = 3
+    nsims = 300
     # Create metric datafiles for economics modelling and extract filename for intervention key
     int_keys_fn = prd.create_economics_metric_files(rme_files_path, nsims, ecol_uncert=1, shelt_uncert=0, expert_uncert=1,
-                                  metrics = [area_saved_above_thresh, area_weighted_rci])
+                                  metrics = [rci, rfi])
 
 
 After creating the metric summary files for CREAM, the cost files can be created by sampling the cost models
@@ -53,12 +54,10 @@ of which are specified in `config.csv`.
 
 .. code-block:: python
 
-    # Number of cost model draws
-    n_draws = 2**2
     # Load ID doc which links scenarios to settings and outputs
     ID_key = pd.read_csv(int_keys_fn)
     # Create cost datafiles for the intervention run ids in ID_key
-    cc.calculate_costs(ID_key, n_draws)
+    cc.calculate_costs(ID_key, nsims)
 
 
 The sampled cost files will be available in the `cost_outputs` folder and the metric summary files will be

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -11,12 +11,13 @@ Raw RCI
 The RCI can be calculated using :meth:`process_RME_data.raw_rci`. This metric comprises 5 reef metrics,
     * Relative coral cover
     * Relative shelter volume
-    * Relative cover of juveniles
-    * Inverse relative crown of thorns population (relative to outbreak levels)
-    * Inverse rubble proportion
+    * Relative abundance of juveniles
+    * Relative crown of thorns population (relative to outbreak levels)
+    * Rubble cover
 
 These values are categorised as within Very Good, Good, Fair, Poor or Very Poor condition depending on their
-values and a set of categories compiled by expert elicitation:
+values and a set of categories compiled by expert elicitation. The expert elicitation process was carried out
+at a workshop in October 2021 with 8 coral reef experts elicited.
 
 .. csv-table:: Expert elicitated reef condition metrics
    :header-rows: 1
@@ -24,26 +25,26 @@ values and a set of categories compiled by expert elicitation:
 
 The raw RCI is calculated by asessing the condition of a reef at each timestep for each metric according
 to the above categories. The reef is assigned the condition of the highest category for which 3 or more metrics satisfy
-that category's threshold. The raw expert condition categories of data collected from 7 experts can also be sampled
+that category's threshold. The raw expert condition categories of data collected from 8 experts can also be sampled
 when calculating metrics by setting `expert_uncert=1`.
 
 RTI
 ---
 
-The RTI is calculated as a linear regression on the RCI condition categories, forming a continuous version of
-the RCI. RTI can be calculated using :meth:`process_RME_data.raw_rti`.
+The RTI is a continuous version of the RCI condition categories. RTI can be calculated using
+:meth:`process_RME_data.raw_rti`.
 
 RFI
 ---
 
-The RFI or Reef Fishing Index, estimates the total fish biomas in kg km^2, based on a linear regression of total relative
+The RFI or Reef Fishing Index, estimates the total fish biomas in kg km^2, based on a linear regression of total
 cover. This is based on digitisation of Fig 4A and 6B in Graham and Nash, 2012 `<https://doi.org/10.1007/s00338-012-0984-y>`_
 The RFI can be calculated using :meth:`process_RME_data.rfi`.
 
 RCI
 ---
 The RCI looks at the total area of reef for which the condition is within the Good or Very Good categories.
-Area saved RCI can be calculated using :meth:`process_RME_data.area_saved_rci`.
+RCI can be calculated using :meth:`process_RME_data.area_saved_rci`.
 
 Area weighted RCI
 -----------------

--- a/src/calculate_metrics.py
+++ b/src/calculate_metrics.py
@@ -78,11 +78,11 @@ def indicator_params(result_set, scen_ids, uncertainty_dict=default_uncertainty_
     else:
         sheltervolume_parameters = np.array([
             [-8.31 + np.random.normal(0,0.514), 1.47], # branching from Urbina-Barretto 2021
-            [-8.32 + np.random.normal(0,0.514), 1.50],  # tabular from Urbina-Barretto 2021
-            [-7.37 + np.random.normal(0,0.514), 1.34], # columnar from Urbina-Barretto 2021, assumed similar for corymbose Acropora
-            [-7.37 + np.random.normal(0,0.514), 1.34], # columnar from Urbina-Barretto 2021, assumed similar for corymbose non-Acropora
-            [-9.69 +  np.random.normal(0,0.514), 1.49], # massive from Urbina-Barretto 2021, assumed similar for encrusting and small massives
-            [-9.69 +  np.random.normal(0,0.514), 1.49]])    # massive from Urbina-Barretto 2021,  assumed similar for large massives
+            [-8.32 + np.random.normal(0,0.388), 1.50],  # tabular from Urbina-Barretto 2021
+            [-7.37 + np.random.normal(0,0.561), 1.34], # columnar from Urbina-Barretto 2021, assumed similar for corymbose Acropora
+            [-7.37 + np.random.normal(0,0.561), 1.34], # columnar from Urbina-Barretto 2021, assumed similar for corymbose non-Acropora
+            [-9.69 +  np.random.normal(0,0.603), 1.49], # massive from Urbina-Barretto 2021, assumed similar for encrusting and small massives
+            [-9.69 +  np.random.normal(0,0.603), 1.49]])    # massive from Urbina-Barretto 2021,  assumed similar for large massives
 
     if uncertainty_dict["expert_uncert"] == 0: # If there is no uncertainty from survey, use median results
         G = pd.read_csv('.//datasets//Heneghan_RCI.csv')
@@ -106,9 +106,9 @@ def indicator_params(result_set, scen_ids, uncertainty_dict=default_uncertainty_
 
     ## RTI LINEAR REGRESSION UNCERTAINTY
     if uncertainty_dict["rti_uncert"] == 0:
-        rti_intercept = -0.498 # Intercept of rci to rti linear equation
+        rti_intercept = -0.871 # Intercept of rci to rti linear equation
     else:
-        rti_intercept = -0.498 + np.random.normal(0, 0.163) # Intercept of rci to rti linear equation
+        rti_intercept = -0.871 + np.random.normal(0, 0.0036) # Intercept of rci to rti linear equation
 
     ## RFI BUILT FROM DIGITISING FIG 4A AND FIG 6B FROM Graham and Nash, 2012 https://doi.org/10.1007/s00338-012-0984-y
 
@@ -260,9 +260,9 @@ def reef_condition_rme(results_data, scen_ids, ecol_uncert, sheltervolume_parame
 def rti_rme(ecol_indicators, rti_intercept):
     # Calculate RTI, which is just the RCI made continuous (coefficients calculated previously,
     # by fitting linear regression of discrete RCI to the 6 ecological indicators underpinning it
-    all_reeftourism = rti_intercept + 0.291*ecol_indicators["total_cover"]
-    + 0.628*ecol_indicators["shelter_volume"] + 1.335*ecol_indicators["coraljuv_relative"]
-    + 0.212*ecol_indicators["COTSrel_complementary"] + 0.250*ecol_indicators["rubble_complementary"]
+    all_reeftourism = rti_intercept + 0.7678 *ecol_indicators["total_cover"]
+    + 0.2945*ecol_indicators["shelter_volume"] + 0.8371*ecol_indicators["coraljuv_relative"]
+    + 0.2822*ecol_indicators["COTSrel_complementary"] + 0.7764*ecol_indicators["rubble_complementary"]
 
     all_reeftourism[all_reeftourism > 0.9] = 0.9
     all_reeftourism[all_reeftourism < 0.1] = 0.1

--- a/src/calculate_metrics.py
+++ b/src/calculate_metrics.py
@@ -170,6 +170,7 @@ def reef_condition_rme(results_data, scen_ids, ecol_uncert, sheltervolume_parame
         nb_coral_juv = np.mean(results_data["nb_coral_juv"][scen_ids, :, :], axis=0)
         rubble = np.mean(results_data["rubble"][scen_ids, :, :], axis=0)
         relative_shelter_volume = np.mean(results_data["relative"][scen_ids, :, :], axis=0)
+        curr_eco_sim = scen_ids[0]
 
     if ecol_uncert == 1: # If we want eco model uncertainty, sample from 20 reefmod simulations
         curr_eco_sim = random.choices(scen_ids, k=nsims)
@@ -255,7 +256,7 @@ def reef_condition_rme(results_data, scen_ids, ecol_uncert, sheltervolume_parame
     reefcondition[reefcondition == sum(crit_val[3:])] = 0.3
     reefcondition[reefcondition == 0.0] = 0.1
 
-    return {"total_cover": total_cover, "shelter_volume": shelterVolume, "coraljuv_relative": coraljuv_relative, "COTSrel_complementary": COTSrel_complementary, "rubble_complementary": rubble_complementary, "RCI" : reefcondition}
+    return {"total_cover": total_cover, "shelter_volume": shelterVolume, "coraljuv_relative": coraljuv_relative, "COTSrel_complementary": COTSrel_complementary, "rubble_complementary": rubble_complementary, "RCI" : reefcondition}, curr_eco_sim
 
 def rti_rme(ecol_indicators, rti_intercept):
     # Calculate RTI, which is just the RCI made continuous (coefficients calculated previously,
@@ -296,11 +297,11 @@ def indicator_master(result_set, scen_ids, nsims, uncertainty_dict=default_uncer
     maxcoraljuv, sheltervolume_parameters, rci_crit, rti_intercept, intercept1, intercept2, slope1, slope2 = indicator_params(result_set, scen_ids, uncertainty_dict=uncertainty_dict)
 
     # Calculate RCI and ecological indicators
-    ecol_indicators = reef_condition_rme(result_set, scen_ids, uncertainty_dict["ecol_uncert"], sheltervolume_parameters, rci_crit, maxcoraljuv, nsims)
+    ecol_indicators, ecol_sample_ids = reef_condition_rme(result_set, scen_ids, uncertainty_dict["ecol_uncert"], sheltervolume_parameters, rci_crit, maxcoraljuv, nsims)
     ecol_indicators["RTI"] = rti_rme(ecol_indicators, rti_intercept)
     ecol_indicators["RFI"] = rfi_rme(ecol_indicators["total_cover"], intercept1, slope1, intercept2, slope2)
 
-    return ecol_indicators
+    return ecol_indicators, ecol_sample_ids
 
 def extract_metrics(results_data, scen_ids, nsims, uncertainty_dict=default_uncertainty_dict()):
     """
@@ -336,11 +337,11 @@ def extract_metrics(results_data, scen_ids, nsims, uncertainty_dict=default_unce
     num_reefs = len(results_data['locations'][:])
     m = num_reefs*num_years
 
-    ecol_indicators = indicator_master(results_data, scen_ids, nsims, uncertainty_dict=uncertainty_dict)
+    ecol_indicators, ecol_sample_ids = indicator_master(results_data, scen_ids, nsims, uncertainty_dict=uncertainty_dict)
 
     #save_metrics = np.zeros((nsims, m, len(ecol_indicators)))
     # Extract outputs and convert to long-form format, then save
     for m_key in ecol_indicators:
         ecol_indicators[m_key] = np.reshape(ecol_indicators[m_key][:, :, 0:num_years], (nsims, m))
 
-    return ecol_indicators
+    return ecol_indicators, ecol_sample_ids

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -166,18 +166,18 @@ def update_setupcost_factors(factors_df_dep, factors_df_prod, ID_key):
 
     return factors_df_dep, factors_df_prod
 
-def calculate_costs(ID_key, n_draws, deploy_model_filepath=config["deploy_model_filepath"],
+def calculate_costs(ID_key, nsims, deploy_model_filepath=config["deploy_model_filepath"],
                  prod_model_filepath=config["prod_model_filepath"], cont_p = 0.8):
     """
-    Sample costs for a set of interventions specified in ID_key, sampling n_draws.
+    Sample costs for a set of interventions specified in ID_key, sampling nsims.
 
     Parameters
     ----------
         ID_key : dataframe
             Dataframe created by running create_economics_metric_files connecting economics metric files to
             intervention scenario IDs and parameters.
-        n_draws : int
-            Number of draws to sample cost models.
+        nsims : int
+            Total number of draws to sample cost models, should match ecological metrics sampling.
         deploy_model_filepath : string
             Path to deployment cost model.
         prod_model_filepath : string
@@ -186,50 +186,51 @@ def calculate_costs(ID_key, n_draws, deploy_model_filepath=config["deploy_model_
             Contingency cost proportion.
     """
     for scen_id in np.unique(ID_key.ID):
-        n_reps = int(max(ID_key.rep)) # Number of rme reps (ecological uncertainty)
+        nreps = int(max(ID_key.rep)) # Number of rme reps (ecological uncertainty)
         scen_idx = ID_key.ID==scen_id # Intervention scenario ID to link costs to ecological model outcomes
         int_years = ID_key.intervention_years[scen_idx] # Intervention years
 
-        # Sample cost model factorswith n draws
-        factor_specs_dep, factors_df_dep, factor_specs_prod, factors_df_prod, n_factors = factors_dataframe_update(n_draws)
-        N = get_N(n_draws, n_factors)
-        cost_df = initialise_cost_df(np.unique(int_years), N*n_reps)
+        # Calculate number of draws needed for nsims with nreps
+        # Want a dataframe approx the size of nsims, including nreps
+        ndraws = int(np.ceil(nsims/nreps))
+
+        cost_df = initialise_cost_df(np.unique(int_years), nsims)
+
+        factor_specs_dep, factors_df_dep, factor_specs_prod, factors_df_prod, nfactors, N = factors_dataframe_update(nsims)
 
         for (int_yr_idx, int_yr) in enumerate(int_years):
-            for rep in range(n_reps):
-                # Add key intervention parameters for year to dataframe as constants
-                factors_df_dep, factors_df_prod = update_factors(factors_df_dep.iloc[0:N], factors_df_prod.iloc[0:N], ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_yr)&(ID_key.rep==rep+1)])
 
-                # Sample deployment and production costs for dataframe parameters
-                factors_df_dep = sample_deployment_cost(deploy_model_filepath, factors_df_dep, factor_specs_dep, n_draws, n_factors=n_factors)
-                factors_df_prod = sample_production_cost(prod_model_filepath, factors_df_prod, factor_specs_prod, n_draws, n_factors=n_factors)
+            # Add key intervention parameters for year to dataframe as constants
+            factors_df_dep, factors_df_prod = update_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_yr)&scen_idx], ndraws, nsims)
 
-                if int_yr>int_years.iloc[0]:
-                    # Save calculated operrational costs
-                    save_cost_prod = factors_df_prod["Cost"]
-                    save_cost_dep = factors_df_dep["Cost"]
+            # Sample deployment and production costs for dataframe parameters
+            factors_df_dep = sample_deployment_cost(deploy_model_filepath, factors_df_dep, factor_specs_dep, N, n_factors=nfactors)
+            factors_df_prod = sample_production_cost(prod_model_filepath, factors_df_prod, factor_specs_prod, N, n_factors=nfactors)
 
-                    # Adjust number of corals to "how many more are being deployed this year than last year?" to caculate setup cost correctly
-                    factors_df_dep, factors_df_prod = update_setupcost_factors(factors_df_dep.iloc[0:N], factors_df_prod.iloc[0:N], ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_years.iloc[int_yr_idx-1])&(ID_key.rep==rep+1)])
+            if int_yr>int_years.iloc[0]:
+                # Save calculated operrational costs
+                save_cost_prod = factors_df_prod["Cost"]
+                save_cost_dep = factors_df_dep["Cost"]
 
-                    if all(factors_df_dep['num_devices']<=0):
-                        # If deploying no more than previous year, setup cost is zero
-                        factors_df_prod["setupCost"] = 0
-                        factors_df_dep["setupCost"] = 0
-                    else:
-                        # If deploying more than last year, recalculate setup cost for only those additional corals
-                        factors_df_dep = sample_deployment_cost(deploy_model_filepath, factors_df_dep, factor_specs_dep, n_draws, n_factors=n_factors)
-                        factors_df_prod = sample_production_cost(prod_model_filepath, factors_df_prod, factor_specs_prod, n_draws, n_factors=n_factors)
+                # Adjust number of corals to "how many more are being deployed this year than last year?" to caculate setup cost correctly
+                factors_df_dep, factors_df_prod = update_setupcost_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_years.iloc[int_yr_idx-1])])
 
-                        # Retain originally sampled operational cost for full number of corals, regardless of intervention year
-                        factors_df_prod["Cost"] = save_cost_prod
-                        factors_df_dep["Cost"] = save_cost_dep
+                if all(factors_df_dep['num_devices']<=0):
+                    # If deploying no more than previous year, setup cost is zero
+                    factors_df_prod["setupCost"] = 0
+                    factors_df_dep["setupCost"] = 0
+                else:
+                    # If deploying more than last year, recalculate setup cost for only those additional corals
+                    factors_df_dep = sample_deployment_cost(deploy_model_filepath, factors_df_dep, factor_specs_dep, N, n_factors=nfactors)
+                    factors_df_prod = sample_production_cost(prod_model_filepath, factors_df_prod, factor_specs_prod, N, n_factors=nfactors)
 
-                # Calculate all cost codes and add to dataframe
-                cost_df.loc[cost_df.year==int_yr, cost_df.columns[rep*N+2:rep*N+N+2]] = cost_types(factors_df_dep[["Cost","setupCost"]] + factors_df_prod[["Cost","setupCost"]], cont_p, N)
+                    # Retain originally sampled operational cost for full number of corals, regardless of intervention year
+                    factors_df_prod["Cost"] = save_cost_prod
+                    factors_df_dep["Cost"] = save_cost_dep
 
-                # Drop cost columns
-                factors_df_dep = factors_df_dep.drop(columns=["Cost","setupCost"])
-                factors_df_prod = factors_df_prod.drop(columns=["Cost","setupCost"])
+            # Calculate all cost codes and add to dataframe
+            cost_sum = (factors_df_dep[["Cost","setupCost"]] + factors_df_prod[["Cost","setupCost"]]).values[0:nsims, :]
+            cost_df.loc[cost_df.year==int_yr, cost_df.columns[2:]] = cost_types(cost_sum, cont_p, nsims)
+
 
         cost_df.to_csv('./cost_outputs/intervention'+str(scen_id)+'_mc_cost_data.csv')

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -234,4 +234,4 @@ def calculate_costs(ID_key_fn, nsims, deploy_model_filepath=config["deploy_model
             cost_df.loc[cost_df.year==int_yr, cost_df.columns[2:]] = cost_types(cost_sum, cont_p, nsims)
 
 
-        cost_df.to_csv('./cost_outputs/intervention'+str(scen_id)+'_mc_cost_data.csv')
+        cost_df.to_csv('./cost_outputs/ID'+str(scen_id)+'intervention_mc_cost_data.csv')

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -123,7 +123,7 @@ def factors_dataframe_update(nsims):
 
     return factor_specs_dep, factors_df_dep.iloc[0:N*K], factor_specs_prod, factors_df_prod.iloc[0:N*K], nfactors, N
 
-def update_factors(factors_df_dep, factors_df_prod, ID_key, ndraws, nsims):
+def update_factors(factors_df_dep, factors_df_prod, ID_key, ecol_idx, nsims):
     """
     Update sampled cost model parameter dataframes with intervention specific parameters.
 
@@ -139,8 +139,8 @@ def update_factors(factors_df_dep, factors_df_prod, ID_key, ndraws, nsims):
             Number of draws required for sample size of nsims, including nreps ecological
             samples in the metrics.
     """
-    factors_df_dep.loc[0:nsims-1, 'num_devices'] = np.repeat(ID_key["number_of_1YO_corals"].values, ndraws)
-    factors_df_prod.loc[0:nsims-1, 'num_devices'] = np.repeat(ID_key["number_of_1YO_corals"].values, ndraws)
+    factors_df_dep.loc[0:nsims-1, 'num_devices'] = ID_key["number_of_1YO_corals"].values[ecol_idx]
+    factors_df_prod.loc[0:nsims-1, 'num_devices'] = ID_key["number_of_1YO_corals"].values[ecol_idx]
     factors_df_prod['species_no'] = ID_key["number_of_species"].iloc[0]
     factors_df_dep['port'] = int(ID_key["port_id"].iloc[0])
     factors_df_dep['distance_from_port'] = ID_key["distance_to_port_NM"].iloc[0]
@@ -185,23 +185,24 @@ def calculate_costs(ID_key, nsims, deploy_model_filepath=config["deploy_model_fi
         cont_p : float
             Contingency cost proportion.
     """
+    ID_key = pd.read_csv( ".\\intervention_keys\\intervention_ID_key_"+ID_key_fn+".csv")
+    ecol_ids_df = pd.read_csv( ".\\intervention_keys\\intervention_rep_idx_"+ID_key_fn+".csv")
     for scen_id in np.unique(ID_key.ID):
         nreps = int(max(ID_key.rep)) # Number of rme reps (ecological uncertainty)
         scen_idx = ID_key.ID==scen_id # Intervention scenario ID to link costs to ecological model outcomes
         int_years = ID_key.intervention_years[scen_idx] # Intervention years
 
-        # Calculate number of draws needed for nsims with nreps
-        # Want a dataframe approx the size of nsims, including nreps
-        ndraws = int(np.ceil(nsims/nreps))
+        # Ecological rep sampling indices (- min because the indices should be relative to the vector selected
+        # for the intervention id)
+        ecol_ids = ecol_ids_df[str(scen_id)] - min(ecol_ids_df[str(scen_id)])
 
         cost_df = initialise_cost_df(np.unique(int_years), nsims)
 
         factor_specs_dep, factors_df_dep, factor_specs_prod, factors_df_prod, nfactors, N = factors_dataframe_update(nsims)
 
         for (int_yr_idx, int_yr) in enumerate(int_years):
-
             # Add key intervention parameters for year to dataframe as constants
-            factors_df_dep, factors_df_prod = update_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_yr)&scen_idx], ndraws, nsims)
+            factors_df_dep, factors_df_prod = update_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_yr)&scen_idx], ecol_ids, nsims)
 
             # Sample deployment and production costs for dataframe parameters
             factors_df_dep = sample_deployment_cost(deploy_model_filepath, factors_df_dep, factor_specs_dep, N, n_factors=nfactors)

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -18,13 +18,17 @@ def load_config():
 
 config = load_config()
 
-def get_N(n_draws, n_factors):
+def get_NK(nsims, n_factors):
     """
-    Calculate number of sobol samples given number of draws and number of factors.
+    Calculate number of input Sobol samples, N, given number of total simulations required and number of factors.
+    Want an output number of samples, N*K , as close to the required number of sims as possible, where
+    K = (2*n_factors + 2).
+    See https://salib.readthedocs.io/en/latest/api.html#sobol-sensitivity-analysis
     """
-    return n_draws * ((2 * n_factors) + 2)
+    K = int((2*n_factors) + 2)
+    return int(np.ceil(nsims/K)), K
 
-def cost_types(cost, contingency, N):
+def cost_types(cost, contingency, nsims):
     """
     Calculate key cost codes:
     1 - CAPEX - sum of production and deployment cost

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -46,16 +46,16 @@ def cost_types(cost, contingency, nsims):
     Parameters
     ----------
         cost : dataframe
-            Dataframe containing 'Cost' and 'setupCost' columns.
+            Dataframe containing 'Cost' and 'setupCost'
         contingency : float
             Contingency proportion.
-        N : int
-            Number of samples
+        nsims : int
+            Total number of simulations (from metrics sampling)
     """
-    cost = np.reshape(np.array(cost), (2,N))
-    return np.vstack((np.vstack((cost[0,:], cost[0,:]*contingency, cost[1,:], np.zeros(N), cost[1,:]*contingency)), np.zeros((6, N))))
+    cost = np.reshape(cost, (2, nsims))
+    return np.vstack((np.vstack((cost[0, :], cost[0, :]*contingency, cost[1, :], np.zeros(nsims), cost[1,:]*contingency)), np.zeros((6, nsims))))
 
-def initialise_cost_df(years, N):
+def initialise_cost_df(years, nsims):
     """
     Initialize dataframe for storing sampled cost data.
 
@@ -63,8 +63,8 @@ def initialise_cost_df(years, N):
     ----------
         years : np.array
             Intervention years
-        N : int
-            Number of cost data samples
+        nsims : int
+            Total number of simulations (from metrics sampling)
 
     Returns
     -------
@@ -72,20 +72,20 @@ def initialise_cost_df(years, N):
     """
     # Dataframe for saving cost data to
     n_years = len(years)
-    cols = ["year", "component"] + ["draw"+str(n) for n in range(1, N+1)]
-    cost_df = pd.DataFrame(np.zeros((n_years*11, 2 + N)), columns=cols)
+    cols = ["year", "component"] + ["draw"+str(n) for n in range(1, nsims+1)]
+    cost_df = pd.DataFrame(np.zeros((n_years*11, 2 + nsims)), columns=cols)
     cost_df["year"] = np.array(np.repeat(years, 11))
-    cost_df["component"] = np.tile(np.array(range(1, 12)),n_years)
+    cost_df["component"] = np.tile(np.array(range(1, 12)), n_years)
     return cost_df
 
-def factors_dataframe_update(n_draws):
+def factors_dataframe_update(nsims):
     """
     Sample cost model parameters.
 
     Parameters
     ----------
-        n_draws : int
-            Number of draws to sample
+        nsims : int
+            Total number of simulations (from metrics sampling)
 
     Returns
     -------
@@ -97,28 +97,33 @@ def factors_dataframe_update(n_draws):
             Factor specification for sampling factors in the production cost model.
         factors_df_prod : dataframe
             Sampled factors dataframe for the production cost model
-        n_factors : int
+        nfactors : int
             Min number of factors in models.
+        N : int
+            Number of simulations to input to Sobol sampling to achieve approx nsims draws
     """
+
     # Sample deployment model factors
     sp_dep, factor_specs_dep = problem_spec("deployment")
-    sp_dep.sample_sobol(n_draws, calc_second_order=True)
+    sp_prod, factor_specs_prod = problem_spec("production")
 
+    nfactors = np.min([factor_specs_dep.shape[0], factor_specs_prod.shape[0]]) - 2
+    N, K = get_NK(nsims, nfactors)
+
+    sp_dep.sample_sobol(N, calc_second_order=True, skip_values=2**N)
     factors_df_dep = pd.DataFrame(data=sp_dep.samples, columns=factor_specs_dep.factor_names)
 
     # Sample production model factors
-    sp_prod, factor_specs_prod = problem_spec("production")
-    sp_prod.sample_sobol(n_draws, calc_second_order=True)
+    sp_prod.sample_sobol(N, calc_second_order=True, skip_values=2**N)
     factors_df_prod = pd.DataFrame(data=sp_prod.samples, columns=factor_specs_prod.factor_names)
 
     # Convert factor types to suitable format for cost model sampling
     factors_df_dep = convert_factor_types(factors_df_dep, factor_specs_dep.is_cat)
     factors_df_prod = convert_factor_types(factors_df_prod, factor_specs_prod.is_cat)
-    n_factors = np.min([factors_df_dep.shape[1], factors_df_prod.shape[1]])
 
-    return factor_specs_dep, factors_df_dep, factor_specs_prod, factors_df_prod, n_factors
+    return factor_specs_dep, factors_df_dep.iloc[0:N*K], factor_specs_prod, factors_df_prod.iloc[0:N*K], nfactors, N
 
-def update_factors(factors_df_dep, factors_df_prod, ID_key):
+def update_factors(factors_df_dep, factors_df_prod, ID_key, ndraws, nsims):
     """
     Update sampled cost model parameter dataframes with intervention specific parameters.
 
@@ -130,9 +135,12 @@ def update_factors(factors_df_dep, factors_df_prod, ID_key):
             Factors dataframe for the production cost model
         ID_key : dataframe
             Intervention specification dataframe containing intervention parameters.
+        ndraws : int
+            Number of draws required for sample size of nsims, including nreps ecological
+            samples in the metrics.
     """
-    factors_df_dep['num_devices'] = ID_key["number_of_1YO_corals"].iloc[0]
-    factors_df_prod['num_devices'] = ID_key["number_of_1YO_corals"].iloc[0]
+    factors_df_dep.loc[0:nsims-1, 'num_devices'] = np.repeat(ID_key["number_of_1YO_corals"].values, ndraws)
+    factors_df_prod.loc[0:nsims-1, 'num_devices'] = np.repeat(ID_key["number_of_1YO_corals"].values, ndraws)
     factors_df_prod['species_no'] = ID_key["number_of_species"].iloc[0]
     factors_df_dep['port'] = int(ID_key["port_id"].iloc[0])
     factors_df_dep['distance_from_port'] = ID_key["distance_to_port_NM"].iloc[0]

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -166,7 +166,7 @@ def update_setupcost_factors(factors_df_dep, factors_df_prod, ID_key):
 
     return factors_df_dep, factors_df_prod
 
-def calculate_costs(ID_key, nsims, deploy_model_filepath=config["deploy_model_filepath"],
+def calculate_costs(ID_key_fn, nsims, deploy_model_filepath=config["deploy_model_filepath"],
                  prod_model_filepath=config["prod_model_filepath"], cont_p = 0.8):
     """
     Sample costs for a set of interventions specified in ID_key, sampling nsims.

--- a/src/example-process-rme-runs.py
+++ b/src/example-process-rme-runs.py
@@ -3,16 +3,14 @@ import process_RME_data as prd
 import pandas as pd
 
 # Filepath to RME runs to process
-rme_files_path = "C:\\Users\\rcrocker\\Documents\\Github\\ReefModEngine.jl\\sandbox\\test_results_econ_metrics"
+rme_files_path = "path to RME output files"
 
 # Number of sims for metrics sampling (default includes ecological and expert uncertainty in RCI calcs)
-nsims = 3
+nsims = 300
 # Create metric datafiles for economics modelling and extract filename for intervention key
 int_keys_fn = prd.create_economics_metric_files(rme_files_path, nsims)
-# Number of cost model draws
-n_draws = 2**2
 
 # Load ID doc which links scenarios to settings and outputs
 ID_key = pd.read_csv(int_keys_fn)
 # Create cost datafiles for the intervention run ids in ID_key
-cc.calculate_costs(ID_key, n_draws)
+cc.calculate_costs(ID_key, nsims)

--- a/src/example-process-rme-runs.py
+++ b/src/example-process-rme-runs.py
@@ -10,7 +10,5 @@ nsims = 300
 # Create metric datafiles for economics modelling and extract filename for intervention key
 int_keys_fn = prd.create_economics_metric_files(rme_files_path, nsims)
 
-# Load ID doc which links scenarios to settings and outputs
-ID_key = pd.read_csv(int_keys_fn)
 # Create cost datafiles for the intervention run ids in ID_key
-cc.calculate_costs(ID_key, nsims)
+cc.calculate_costs(int_keys_fn, nsims)

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -236,8 +236,6 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
     start_year = years[0]
     end_year = years[-1]
 
-    data_store = create_base_economics_dataframe(regions_data, reef_spatial_data, years)
-
     # Get unique intervention IDs from result set (unique intervention and climate model)
     intervention_ids = np.unique(scens_df["intervention id"])
 
@@ -245,13 +243,17 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
     unique_iv_scens = np.where(~np.array(iv_dict["counterfactual"]).astype(bool))[0]
     unique_cf_scens = np.where(np.array(iv_dict["counterfactual"]).astype(bool))[0]
 
+    # Setup key storage for metrics datafiles and ecological sample ids
+    data_store = create_base_economics_dataframe(regions_data, reef_spatial_data, years)
+    store_ecol_ids = np.zeros((nsims, len(intervention_ids)), dtype=int)
+
     # Setup key table structure used by economics modelling
     id_key_df_store = pd.DataFrame(columns=['ID', 'results_filename', 'intervention_years', 'number_of_1YO_corals', 'port_id', 'distance_to_port_NM', 'intervention_reef_id', 'number_of_species', 'start_year', 'end_year'])
 
     # Save a csv for each unique intervention, one for cf and one for iv runs
-    for iv_idx in intervention_ids:
+    for (iv_idx, iv_id) in enumerate(intervention_ids):
         # Get scenario table for intervention
-        scens_idx = scens_df["intervention id"]==iv_idx
+        scens_idx = scens_df["intervention id"]==iv_id
         scens_df_iv = scens_df[scens_idx]
         n_reps = max(scens_df_iv["rep"])
 
@@ -262,8 +264,8 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         data_store["year_relative"] = data_store["year_absolute"] - min(scens_df_iv["year"])
 
         # Scenario ids for CF and counterfactual
-        iv_scens = unique_iv_scens[(iv_idx*n_reps-2):(iv_idx*n_reps-2)+n_reps]
-        cf_scens = unique_cf_scens[(iv_idx*n_reps-2):(iv_idx*n_reps-2)+n_reps]
+        iv_scens = unique_iv_scens[(iv_id*n_reps-2):(iv_id*n_reps-2)+n_reps]
+        cf_scens = unique_cf_scens[(iv_id*n_reps-2):(iv_id*n_reps-2)+n_reps]
 
         new_cols = ["sim_{0}".format(i) for i in range(1,nsims+1)]
         data_store[new_cols] = np.zeros((data_store.shape[0], len(new_cols)))
@@ -285,8 +287,10 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         id_key_df["distance_to_port_NM"]= total_dist
 
         # Extract metrics for intervention and counterfactual scenarios
-        metrics_data_iv = extract_metrics(results_data, iv_scens, nsims, uncertainty_dict=uncertainty_dict)
-        metrics_data_cf = extract_metrics(results_data, cf_scens, nsims, uncertainty_dict=uncertainty_dict)
+        metrics_data_iv, ecol_ids = extract_metrics(results_data, iv_scens, nsims, uncertainty_dict=uncertainty_dict)
+        metrics_data_cf, _ = extract_metrics(results_data, cf_scens, nsims, uncertainty_dict=uncertainty_dict)
+
+        store_ecol_ids[:, iv_idx] = ecol_ids
 
         for met_func in metrics:
             data_store[new_cols] = met_func(metrics_data_iv, data_store)
@@ -312,4 +316,8 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
     id_filename = ".\\intervention_keys\\intervention_ID_key_"+rme_files_path.split("\\")[-1]+".csv"
     id_key_df_store.to_csv(id_filename)
 
-    return id_filename
+    store_ecol_ids_df = pd.DataFrame(store_ecol_ids, columns=[str(id) for id in intervention_ids])
+    ecol_id_filename = ".\\intervention_keys\\intervention_rep_idx_"+rme_files_path.split("\\")[-1]+".csv"
+    store_ecol_ids_df.to_csv(ecol_id_filename)
+
+    return rme_files_path.split("\\")[-1]

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -248,7 +248,10 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
     store_ecol_ids = np.zeros((nsims, len(intervention_ids)), dtype=int)
 
     # Setup key table structure used by economics modelling
-    id_key_df_store = pd.DataFrame(columns=['ID', 'results_filename', 'intervention_years', 'number_of_1YO_corals', 'port_id', 'distance_to_port_NM', 'intervention_reef_id', 'number_of_species', 'start_year', 'end_year'])
+    id_key_df_store = pd.DataFrame(columns=['ID', 'results_filename', 'climate_model', 'intervention_years', 'number_of_1YO_corals', 'port_id', 'distance_to_port_NM', 'intervention_reef_id', 'number_of_species', 'start_year', 'end_year'])
+
+    # Base filename for saving metrics
+    base_met_filename = '_uncertainty_ecol'+str(uncertainty_dict["ecol_uncert"])+'_indicator'+str(uncertainty_dict["expert_uncert"])+'_var_'
 
     # Save a csv for each unique intervention, one for cf and one for iv runs
     for (iv_idx, iv_id) in enumerate(intervention_ids):
@@ -294,21 +297,22 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
 
         for met_func in metrics:
             data_store[new_cols] = met_func(metrics_data_iv, data_store)
-            iv_filename = str(iv_idx)+'_intervention_var_'+met_func.__name__+'_ecol0_intervention.csv'
+            iv_filename = 'ID'+str(iv_id)+'_intervention'+base_met_filename+met_func.__name__+'.csv'
             data_store.to_csv(econ_storage_path+iv_filename)
             data_store[new_cols] = met_func(metrics_data_cf, data_store)
-            cf_filename = str(iv_idx)+'_counterfactual_var_'+met_func.__name__+'_ecol0_intervention.csv'
+            cf_filename = 'ID'+str(iv_id)+'_counterfactual'+base_met_filename+met_func.__name__+'.csv'
             data_store.to_csv(econ_storage_path+cf_filename)
 
         # Drop data columns to allow those for next intervention to be added
         data_store = data_store.drop(new_cols, axis=1)
 
         # Add to record key data for cost modelling
-        id_key_df["results_filename"] = 'intervention'+str(iv_idx)+'_metric_name_ecol0_intervention.csv'
+        id_key_df["results_filename"] = iv_filename
         id_key_df["port_id"] = 1 # Doesn't matter because we have distance to port
         id_key_df["number_of_species"] = 6 # Set at 6 as RME
         id_key_df["start_year"] = start_year
         id_key_df["end_year"] = end_year
+        id_key_df["climate_model"] = scens_idx["GCM name"][0]
         id_key_df = id_key_df.rename(columns={'number of corals':'number_of_1YO_corals','intervention id':'ID', 'year':'intervention_years'})
         id_key_df_store = pd.concat([id_key_df_store, id_key_df])
 

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -282,12 +282,12 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         # Store furthest and closest reefs in representative clsuters
         id_key_df["furthest_representative_reef"] = rep_reefs_sort[-1]
         id_key_df["closest_representative_reef"] = rep_reefs_sort[0]
-        id_key_df["distance_to_port_NM"] = total_dist
+        id_key_df["distance_to_port_NM"]= total_dist
 
         # Extract metrics for intervention and counterfactual scenarios
         metrics_data_iv = extract_metrics(results_data, iv_scens, nsims, uncertainty_dict=uncertainty_dict)
         metrics_data_cf = extract_metrics(results_data, cf_scens, nsims, uncertainty_dict=uncertainty_dict)
-        breakpoint()
+
         for met_func in metrics:
             data_store[new_cols] = met_func(metrics_data_iv, data_store)
             iv_filename = str(iv_idx)+'_intervention_var_'+met_func.__name__+'_ecol0_intervention.csv'


### PR DESCRIPTION
Cost model simulation numbers need to match metrics sampling numbers (nsims, or the total number of samples taken to calculate output metrics) to work with the economics model input file format.

As Sobol sampling is used to sample the cost model parameters, the total number of  Sobol samples is related to the number of factors, nfactors, and N through
nsamples = N(2*nfactors +2).

This PR details changes to ensure nsamples is approximately nsims (with additional samples shaved off in file saving). This is done by ensuring N $\approx$ nsims/(2*nfactors +2).

As slightly different numbers of corals may be outplanted in different climate repetitions of the same climate model and SSP, the number of repetitions (nreps) also needs to be incorporated in the cost model sampling.

This PR also ensures that nsims $\approx$ nsamples =  nreps*ndraws, where ndraws is the number of times parameters are drawn using Sobol sampling for a particular climate repetition. This done by passing the indices used to sample climate repetitions in the metrics to the cost sampling function. The indices are then used to ensure the number of corals outplanted for each scenario in the cost model matches the coresponding sample in the metrics file.