### PR TITLE
Fixes to how years with zero setup cost are treated for better efficiency

### DIFF
--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -215,18 +215,26 @@ def calculate_costs(ID_key_fn, nsims, deploy_model_filepath=config["deploy_model
                 # Adjust number of corals to "how many more are being deployed this year than last year?" to caculate setup cost correctly
                 factors_df_dep, factors_df_prod = update_setupcost_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_years.iloc[int_yr_idx-1])])
 
-                if all(factors_df_dep['num_devices']<=0):
+                if any(factors_df_dep['num_devices']<=0):
                     # If deploying no more than previous year, setup cost is zero
-                    factors_df_prod["setupCost"] = 0
-                    factors_df_dep["setupCost"] = 0
-                else:
-                    # If deploying more than last year, recalculate setup cost for only those additional corals
-                    factors_df_dep = sample_deployment_cost(deploy_model_filepath, factors_df_dep, factor_specs_dep, N, n_factors=nfactors)
-                    factors_df_prod = sample_production_cost(prod_model_filepath, factors_df_prod, factor_specs_prod, N, n_factors=nfactors)
+                    factors_df_prod.loc[factors_df_dep['num_devices']<=0, "setupCost"] = 0
+                    factors_df_dep.loc[factors_df_dep['num_devices']<=0, "setupCost"] = 0
 
-                    # Retain originally sampled operational cost for full number of corals, regardless of intervention year
-                    factors_df_prod["Cost"] = save_cost_prod
-                    factors_df_dep["Cost"] = save_cost_dep
+                if any(factors_df_dep['num_devices']>0):
+                    # This will make the new number of samples equal to the number of scenarios with num_devices>0
+                    N_new = sum(factors_df_dep['num_devices']>0)/(2 * nfactors + 2)
+
+                    # If deploying more than last year, recalculate setup cost for only those additional corals
+                    factors_df_dep_new = sample_deployment_cost(deploy_model_filepath, factors_df_dep.loc[factors_df_dep['num_devices']>0,:], factor_specs_dep, N_new, n_factors=nfactors)
+                    factors_df_prod_new = sample_production_cost(prod_model_filepath, factors_df_prod.loc[factors_df_dep['num_devices']>0,:], factor_specs_prod, N_new, n_factors=nfactors)
+
+                    # Replace orginally calculated setup costs with updated setup costs
+                    factors_df_prod.loc[factors_df_dep['num_devices']>0, "setupCost"] = factors_df_prod_new["setupCost"]
+                    factors_df_dep.loc[factors_df_dep['num_devices']>0, "setupCost"] = factors_df_dep_new["setupCost"]
+
+                # Retain originally sampled operational cost for full number of corals, regardless of intervention year
+                factors_df_prod["Cost"] = save_cost_prod
+                factors_df_dep["Cost"] = save_cost_dep
 
             # Calculate all cost codes and add to dataframe
             cost_sum = (factors_df_dep[["Cost","setupCost"]] + factors_df_prod[["Cost","setupCost"]]).values[0:nsims, :]

--- a/src/cost_calculations.py
+++ b/src/cost_calculations.py
@@ -74,8 +74,8 @@ def initialise_cost_df(years, nsims):
     n_years = len(years)
     cols = ["year", "component"] + ["draw"+str(n) for n in range(1, nsims+1)]
     cost_df = pd.DataFrame(np.zeros((n_years*11, 2 + nsims)), columns=cols)
-    cost_df["year"] = np.array(np.repeat(years, 11))
-    cost_df["component"] = np.tile(np.array(range(1, 12)), n_years)
+    cost_df.loc[:, "year"] = np.array(np.repeat(years, 11))
+    cost_df.loc[:, "component"] = np.tile(np.array(range(1, 12)), n_years)
     return cost_df
 
 def factors_dataframe_update(nsims):
@@ -141,9 +141,9 @@ def update_factors(factors_df_dep, factors_df_prod, ID_key, ecol_idx, nsims):
     """
     factors_df_dep.loc[0:nsims-1, 'num_devices'] = ID_key["number_of_1YO_corals"].values[ecol_idx]
     factors_df_prod.loc[0:nsims-1, 'num_devices'] = ID_key["number_of_1YO_corals"].values[ecol_idx]
-    factors_df_prod['species_no'] = ID_key["number_of_species"].iloc[0]
-    factors_df_dep['port'] = int(ID_key["port_id"].iloc[0])
-    factors_df_dep['distance_from_port'] = ID_key["distance_to_port_NM"].iloc[0]
+    factors_df_prod.loc[:, 'species_no'] = ID_key["number_of_species"].iloc[0]
+    factors_df_dep.loc[:, 'port'] = 1 # Port does not matter as we are using distance to port directly
+    factors_df_dep.loc[:, 'distance_from_port'] = ID_key["distance_to_port_NM"].iloc[0]
 
     return factors_df_dep, factors_df_prod
 
@@ -161,8 +161,8 @@ def update_setupcost_factors(factors_df_dep, factors_df_prod, ID_key):
         ID_key : dataframe
             Intervention specification dataframe containing intervention parameters.
     """
-    factors_df_dep['num_devices'] = factors_df_dep['num_devices'] - ID_key["number_of_1YO_corals"].iloc[0]
-    factors_df_prod['num_devices'] = factors_df_prod['num_devices'] - ID_key["number_of_1YO_corals"].iloc[0]
+    factors_df_dep.loc[:, 'num_devices'] = factors_df_dep['num_devices'] - ID_key["number_of_1YO_corals"].iloc[0]
+    factors_df_prod.loc[:, 'num_devices'] = factors_df_prod['num_devices'] - ID_key["number_of_1YO_corals"].iloc[0]
 
     return factors_df_dep, factors_df_prod
 
@@ -201,7 +201,7 @@ def calculate_costs(ID_key_fn, nsims, deploy_model_filepath=config["deploy_model
 
         for (int_yr_idx, int_yr) in enumerate(int_years):
             # Add key intervention parameters for year to dataframe as constants
-            factors_df_dep, factors_df_prod = update_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_yr)&scen_idx], ecol_ids, nsims)
+            factors_df_dep, factors_df_prod = update_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_yr)&scen_idx], ecol_ids, nsims)
 
             # Sample deployment and production costs for dataframe parameters
             factors_df_dep = sample_deployment_cost(deploy_model_filepath, factors_df_dep, factor_specs_dep, N, n_factors=nfactors)
@@ -213,7 +213,7 @@ def calculate_costs(ID_key_fn, nsims, deploy_model_filepath=config["deploy_model
                 save_cost_dep = factors_df_dep["Cost"]
 
                 # Adjust number of corals to "how many more are being deployed this year than last year?" to caculate setup cost correctly
-                factors_df_dep, factors_df_prod = update_setupcost_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals", "port_id", "distance_to_port_NM", "number_of_species"]].loc[(ID_key.intervention_years==int_years.iloc[int_yr_idx-1])])
+                factors_df_dep, factors_df_prod = update_setupcost_factors(factors_df_dep, factors_df_prod, ID_key[["number_of_1YO_corals"]].loc[(ID_key.intervention_years==int_years.iloc[int_yr_idx-1])])
 
                 if any(factors_df_dep['num_devices']<=0):
                     # If deploying no more than previous year, setup cost is zero
@@ -233,8 +233,8 @@ def calculate_costs(ID_key_fn, nsims, deploy_model_filepath=config["deploy_model
                     factors_df_dep.loc[factors_df_dep['num_devices']>0, "setupCost"] = factors_df_dep_new["setupCost"]
 
                 # Retain originally sampled operational cost for full number of corals, regardless of intervention year
-                factors_df_prod["Cost"] = save_cost_prod
-                factors_df_dep["Cost"] = save_cost_dep
+                factors_df_prod.loc[:, "Cost"] = save_cost_prod
+                factors_df_dep.loc[:, "Cost"] = save_cost_dep
 
             # Calculate all cost codes and add to dataframe
             cost_sum = (factors_df_dep[["Cost","setupCost"]] + factors_df_prod[["Cost","setupCost"]]).values[0:nsims, :]

--- a/src/example-process-rme-runs.py
+++ b/src/example-process-rme-runs.py
@@ -6,7 +6,7 @@ import pandas as pd
 rme_files_path = "path to RME output files"
 
 # Number of sims for metrics sampling (default includes ecological and expert uncertainty in RCI calcs)
-nsims = 300
+nsims = 10
 # Create metric datafiles for economics modelling and extract filename for intervention key
 int_keys_fn = prd.create_economics_metric_files(rme_files_path, nsims)
 

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -278,10 +278,11 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
 
         # Setup structure for intervention key - links intervention ID and filename to cost model data
         id_key_df = scens_df_iv[["intervention id", "year", "rep", "number of corals"]]
-        n_scens_id = id_key_df.shape[0]
-        id_key_df["distance_to_port_NM"] = np.zeros((n_scens_id,))
-        id_key_df["furthest_representative_reef"] = np.repeat("", (n_scens_id,))
-        id_key_df["closest_representative_reef"] = np.repeat("", (n_scens_id,))
+        n_scens_id, id_key_n_col = id_key_df.shape
+
+        id_key_df.insert(id_key_n_col, "distance_to_port_NM", np.zeros((n_scens_id,)))
+        id_key_df.insert(id_key_n_col+1, "furthest_representative_reef", np.repeat("", (n_scens_id,)))
+        id_key_df.insert(id_key_n_col+2, "closest_representative_reef", np.repeat("", (n_scens_id,)))
 
         # Add distance to port data to save in intervention key
         [rep_reefs_sort, total_dist] = find_max_reef_distance(reef_spatial_data, regions_data, iv_reefs, max_dist = max_dist)

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -253,7 +253,7 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
     # Setup key table structure used by economics modelling
     id_key_df_store = pd.DataFrame(columns=['ID', 'intervention_years', 'rep', 'number_of_1YO_corals',
        'distance_to_port_NM', 'furthest_representative_reef',
-       'closest_representative_reef', 'results_filename', 'port_id',
+       'closest_representative_reef', 'results_filename',
        'number_of_species', 'start_year', 'end_year', 'climate_model'])
 
     # Base filename for saving metrics
@@ -282,7 +282,7 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
 
         id_key_df.insert(id_key_n_col, "distance_to_port_NM", np.zeros((n_scens_id,)))
         id_key_df.insert(id_key_n_col+1, "furthest_representative_reef", np.repeat("", (n_scens_id,)))
-        id_key_df.insert(id_key_n_col+2, "closest_representative_reef", np.repeat("", (n_scens_id,)))
+        id_key_df.insert(id_key_n_col+2, "closest_representative_reef",  np.repeat("", (n_scens_id,)))
 
         # Add distance to port data to save in intervention key
         [rep_reefs_sort, total_dist] = find_max_reef_distance(reef_spatial_data, regions_data, iv_reefs, max_dist = max_dist)
@@ -310,12 +310,13 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         data_store = data_store.drop(sim_cols, axis=1)
 
         # Add to record key data for cost modelling
-        id_key_df["results_filename"] = iv_filename
-        id_key_df["port_id"] = 1 # Doesn't matter because we have distance to port
-        id_key_df["number_of_species"] = 6 # Set at 6 as RME
-        id_key_df["start_year"] = start_year
-        id_key_df["end_year"] = end_year
-        id_key_df["climate_model"] = np.unique(scens_df_iv["GCM name"])[0]
+        id_key_n_col = id_key_df.shape[1]
+
+        id_key_df.insert(id_key_n_col, "results_filename", np.repeat(iv_filename, (n_scens_id,)))
+        id_key_df.insert(id_key_n_col+1,"number_of_species", np.ones((n_scens_id,))*6)
+        id_key_df.insert(id_key_n_col+2, "start_year", np.repeat(start_year, (n_scens_id,)))
+        id_key_df.insert(id_key_n_col+3, "end_year", np.repeat(end_year, (n_scens_id,)))
+        id_key_df.insert(id_key_n_col+4, "climate_model", scens_df_iv["GCM name"].values)
         id_key_df = id_key_df.rename(columns={'number of corals':'number_of_1YO_corals','intervention id':'ID', 'year':'intervention_years'})
 
         id_key_df_store = pd.concat([id_key_df_store, id_key_df])

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -251,7 +251,10 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
     store_ecol_ids = np.zeros((nsims, len(intervention_ids)), dtype=int)
 
     # Setup key table structure used by economics modelling
-    id_key_df_store = pd.DataFrame(columns=['ID', 'results_filename', 'climate_model', 'intervention_years', 'number_of_1YO_corals', 'port_id', 'distance_to_port_NM', 'intervention_reef_id', 'number_of_species', 'start_year', 'end_year'])
+    id_key_df_store = pd.DataFrame(columns=['ID', 'intervention_years', 'rep', 'number_of_1YO_corals',
+       'distance_to_port_NM', 'furthest_representative_reef',
+       'closest_representative_reef', 'results_filename', 'port_id',
+       'number_of_species', 'start_year', 'end_year', 'climate_model'])
 
     # Base filename for saving metrics
     base_met_filename = '_uncertainty_ecol'+str(uncertainty_dict["ecol_uncert"])+'_indicator'+str(uncertainty_dict["expert_uncert"])+'_var_'
@@ -279,7 +282,6 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         id_key_df["distance_to_port_NM"] = np.zeros((n_scens_id,))
         id_key_df["furthest_representative_reef"] = np.repeat("", (n_scens_id,))
         id_key_df["closest_representative_reef"] = np.repeat("", (n_scens_id,))
-
 
         # Add distance to port data to save in intervention key
         [rep_reefs_sort, total_dist] = find_max_reef_distance(reef_spatial_data, regions_data, iv_reefs, max_dist = max_dist)
@@ -314,6 +316,7 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         id_key_df["end_year"] = end_year
         id_key_df["climate_model"] = np.unique(scens_df_iv["GCM name"])[0]
         id_key_df = id_key_df.rename(columns={'number of corals':'number_of_1YO_corals','intervention id':'ID', 'year':'intervention_years'})
+
         id_key_df_store = pd.concat([id_key_df_store, id_key_df])
 
     # Save intervention key for generating cost data file for saved intervention and cf files

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -276,14 +276,18 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         # Setup structure for intervention key - links intervention ID and filename to cost model data
         id_key_df = scens_df_iv[["intervention id", "year", "rep", "number of corals"]]
         n_scens_id = id_key_df.shape[0]
+        id_key_df["distance_to_port_NM"] = np.zeros((n_scens_id,))
+        id_key_df["furthest_representative_reef"] = np.repeat("", (n_scens_id,))
+        id_key_df["closest_representative_reef"] = np.repeat("", (n_scens_id,))
+
 
         # Add distance to port data to save in intervention key
         [rep_reefs_sort, total_dist] = find_max_reef_distance(reef_spatial_data, regions_data, iv_reefs, max_dist = max_dist)
 
         # Store furthest and closest reefs in representative clsuters
-        id_key_df = pd.concat((id_key_df, pd.DataFrame(np.repeat(rep_reefs_sort[-1],(n_scens_id,)), columns=["furthest_representative_reef"])), axis=1)
-        id_key_df = pd.concat((id_key_df, pd.DataFrame(np.repeat(rep_reefs_sort[0],(n_scens_id,)), columns=["closest_representative_reef"])), axis=1)
-        id_key_df = pd.concat((id_key_df, pd.DataFrame(np.repeat(total_dist,(n_scens_id,)), columns=["distance_to_port_NM"])), axis=1)
+        id_key_df.loc[:, "furthest_representative_reef"] = rep_reefs_sort[-1]
+        id_key_df.loc[:, "closest_representative_reef"] = rep_reefs_sort[0]
+        id_key_df.loc[:, "distance_to_port_NM"] = total_dist
 
         # Extract metrics for intervention and counterfactual scenarios
         metrics_data_iv, ecol_ids = extract_metrics(results_data, iv_scens, nsims, uncertainty_dict=uncertainty_dict)

--- a/src/process_RME_data.py
+++ b/src/process_RME_data.py
@@ -245,6 +245,9 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
 
     # Setup key storage for metrics datafiles and ecological sample ids
     data_store = create_base_economics_dataframe(regions_data, reef_spatial_data, years)
+    sim_cols = ["sim_{0}".format(i) for i in range(1,nsims+1)]
+    store_sims = pd.DataFrame(np.zeros((data_store.shape[0], len(sim_cols))), columns = sim_cols)
+    data_store = pd.concat((data_store, store_sims), axis=1)
     store_ecol_ids = np.zeros((nsims, len(intervention_ids)), dtype=int)
 
     # Setup key table structure used by economics modelling
@@ -270,24 +273,17 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         iv_scens = unique_iv_scens[(iv_id*n_reps-2):(iv_id*n_reps-2)+n_reps]
         cf_scens = unique_cf_scens[(iv_id*n_reps-2):(iv_id*n_reps-2)+n_reps]
 
-        new_cols = ["sim_{0}".format(i) for i in range(1,nsims+1)]
-        data_store[new_cols] = np.zeros((data_store.shape[0], len(new_cols)))
-
         # Setup structure for intervention key - links intervention ID and filename to cost model data
         id_key_df = scens_df_iv[["intervention id", "year", "rep", "number of corals"]]
         n_scens_id = id_key_df.shape[0]
-        id_key_df["distance_to_port_NM"] = np.zeros((n_scens_id,))
-        id_key_df["furthest_representative_reef"] = np.repeat("", (n_scens_id,))
-        id_key_df["closest_representative_reef"] = np.repeat("", (n_scens_id,))
-
 
         # Add distance to port data to save in intervention key
         [rep_reefs_sort, total_dist] = find_max_reef_distance(reef_spatial_data, regions_data, iv_reefs, max_dist = max_dist)
 
         # Store furthest and closest reefs in representative clsuters
-        id_key_df["furthest_representative_reef"] = rep_reefs_sort[-1]
-        id_key_df["closest_representative_reef"] = rep_reefs_sort[0]
-        id_key_df["distance_to_port_NM"]= total_dist
+        id_key_df = pd.concat((id_key_df, pd.DataFrame(np.repeat(rep_reefs_sort[-1],(n_scens_id,)), columns=["furthest_representative_reef"])), axis=1)
+        id_key_df = pd.concat((id_key_df, pd.DataFrame(np.repeat(rep_reefs_sort[0],(n_scens_id,)), columns=["closest_representative_reef"])), axis=1)
+        id_key_df = pd.concat((id_key_df, pd.DataFrame(np.repeat(total_dist,(n_scens_id,)), columns=["distance_to_port_NM"])), axis=1)
 
         # Extract metrics for intervention and counterfactual scenarios
         metrics_data_iv, ecol_ids = extract_metrics(results_data, iv_scens, nsims, uncertainty_dict=uncertainty_dict)
@@ -296,15 +292,15 @@ def create_economics_metric_files(rme_files_path, nsims, uncertainty_dict=defaul
         store_ecol_ids[:, iv_idx] = ecol_ids
 
         for met_func in metrics:
-            data_store[new_cols] = met_func(metrics_data_iv, data_store)
+            data_store[sim_cols] = met_func(metrics_data_iv, data_store)
             iv_filename = 'ID'+str(iv_id)+'_intervention'+base_met_filename+met_func.__name__+'.csv'
             data_store.to_csv(econ_storage_path+iv_filename)
-            data_store[new_cols] = met_func(metrics_data_cf, data_store)
+            data_store[sim_cols] = met_func(metrics_data_cf, data_store)
             cf_filename = 'ID'+str(iv_id)+'_counterfactual'+base_met_filename+met_func.__name__+'.csv'
             data_store.to_csv(econ_storage_path+cf_filename)
 
         # Drop data columns to allow those for next intervention to be added
-        data_store = data_store.drop(new_cols, axis=1)
+        data_store = data_store.drop(sim_cols, axis=1)
 
         # Add to record key data for cost modelling
         id_key_df["results_filename"] = iv_filename


### PR DESCRIPTION
Due to changes in how we check for zero setup cost years (check whether we have more or less corals than the previous year), and how sample size is determined in cost_model_queries, we can now sample a smaller number of scenarios where we don't need to recalculate the setup costs. These changes should provide some runtime games as only scenarios which need to be resampled for changing setup costs are sampled (whereas previously cosy_model_queries required a specific size for the number of samples linked to Sobol sampling). There are also some other changes implemented to remove Pandas inefficiency warning messages.