### PR TITLE
Speed up excel interfaces

### DIFF
--- a/cost_eco_model_linker/handlers/excel_handlers.py
+++ b/cost_eco_model_linker/handlers/excel_handlers.py
@@ -32,6 +32,10 @@ def open_excel(fp, xlapp=None):
 
     wb = xlapp.Workbooks.Open(wb_file_path)
 
+    # These properties often fail if set before a workbook is open
+    xlapp.ScreenUpdating = False
+    xlapp.Calculation = -4135  # xlCalculationManual
+
     return xlapp, wb
 
 
@@ -60,10 +64,9 @@ def close_excel(xlapp, wb, quit_app=True):
 
 
 def reset_workbook(xlapp, wb, fp):
-    """Close and reopen workbook to reset to original state"""
-    wb.Close(SaveChanges=False)
-    wb = xlapp.Workbooks.Open(fp)
-
+    """Reset workbook state. (Optimized: No longer re-opens file)"""
+    # In the optimized version, we rely on overwrite-all-inputs behavior
+    # in evaluate_spreadsheet rather than re-opening the file.
     return wb
 
 

--- a/cost_eco_model_linker/sampling.py
+++ b/cost_eco_model_linker/sampling.py
@@ -89,9 +89,14 @@ def evaluate_spreadsheet(wb, model_spec, params) -> tuple[float, float]:
     factor_names = model_spec.factor_names
     not_costs = ~factor_names.isin(["capex", "opex"])
 
-    # Optimized: We write values while Calculation is Manual (set at open_excel)
+    # Optimized: Cache sheet objects to avoid repeated lookups
+    sheets = {}
+
     for _, row in model_spec[not_costs].iterrows():
-        wb.Sheets(row.sheet).Range(row.cell_pos).Value = params[row.factor_names]
+        s_name = row.sheet
+        if s_name not in sheets:
+            sheets[s_name] = wb.Sheets(s_name)
+        sheets[s_name].Range(row.cell_pos).Value = params[row.factor_names]
 
     # Single recalculation for the whole sheet
     wb.Application.Calculate()

--- a/cost_eco_model_linker/sampling.py
+++ b/cost_eco_model_linker/sampling.py
@@ -89,16 +89,12 @@ def evaluate_spreadsheet(wb, model_spec, params) -> tuple[float, float]:
     factor_names = model_spec.factor_names
     not_costs = ~factor_names.isin(["capex", "opex"])
 
-    xlManual = -4135
-    xlAutomatic = -4105
-    wb.Application.Calculation = xlManual
-    try:
-        for _, row in model_spec[not_costs].iterrows():
-            wb.Sheets(row.sheet).Range(row.cell_pos).Value = params[row.factor_names]
-    finally:
-        wb.Application.Calculation = xlAutomatic
+    # Optimized: We write values while Calculation is Manual (set at open_excel)
+    for _, row in model_spec[not_costs].iterrows():
+        wb.Sheets(row.sheet).Range(row.cell_pos).Value = params[row.factor_names]
 
-    wb.Application.CalculateFull()
+    # Single recalculation for the whole sheet
+    wb.Application.Calculate()
     ws = wb.Sheets("Dashboard")
 
     capex_cell = model_spec.loc[factor_names == "capex", "cell_pos"].values[0]


### PR DESCRIPTION
1. Remove workbook resets and opening and closing when we are overwriting the same values.
2. Set screen updating to false
3. Cache sheets that we have already edited to avoid lookups.

Speeds up my parallel runs about 2x