### PR TITLE
Implement seeding for reproducibility across serial and parallel runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ sandbox/
 
 package-lock.json
 model-backup/
+GEMINI.md

--- a/cost_eco_model_linker/calculate_metrics.py
+++ b/cost_eco_model_linker/calculate_metrics.py
@@ -50,7 +50,12 @@ def default_uncertainty_dict() -> dict:
 
 
 def indicator_params(
-    result_set, scen_ids, uncertainty_dict=None, juv_max_years=None, max_coral_juv=None
+    result_set,
+    scen_ids,
+    uncertainty_dict=None,
+    juv_max_years=None,
+    max_coral_juv=None,
+    seed: int = None,
 ):
     """
     Calculates key parameters for shelter volume and RCI calculations given uncertainty sampling choices.
@@ -68,6 +73,8 @@ def indicator_params(
             Interventions cannot start in the first year.
         max_coral_juv : list[float]
             Max juveniles baseline (can be included instead of using hindcasting baseline).
+        seed : int, optional
+            Random seed for reproducibility.
 
     Returns
     -------
@@ -78,6 +85,10 @@ def indicator_params(
         rci_crit : np.array
             Array of thresholds describing reef condition categories.
     """
+    if seed is not None:
+        np.random.seed(seed)
+        random.seed(seed)
+
     if uncertainty_dict is None:
         uncertainty_dict = default_uncertainty_dict()
     if juv_max_years is None:

--- a/cost_eco_model_linker/cost_calculations.py
+++ b/cost_eco_model_linker/cost_calculations.py
@@ -250,7 +250,7 @@ def _fill_eia_missing_years(eia_template, all_years):
     return eia_template
 
 
-def sample_cost_model(nsims):
+def sample_cost_model(nsims, seed: int = None):
     """
     Sample cost model parameters for production, deployment, and LM models.
 
@@ -260,6 +260,8 @@ def sample_cost_model(nsims):
         Total number of simulations (from metrics sampling).  When ``None``
         or ``1`` Sobol' sampling is skipped and a single row of
         ``best_point_value`` entries is returned instead.
+    seed : int, optional
+        Random seed for reproducibility.
 
     Returns
     -------
@@ -308,7 +310,7 @@ def sample_cost_model(nsims):
         # Sample production model factors
         nfactors = np.min([specs_dep.shape[0], specs_prod.shape[0]]) - 2
         N, K = get_NK(nsims, nfactors, calc_second_order=False)
-        sp_prod.sample_sobol(N, calc_second_order=False, skip_values=N)
+        sp_prod.sample_sobol(N, calc_second_order=False, skip_values=N, seed=seed)
         factors_df_prod = pd.DataFrame(
             data=sp_prod.samples, columns=specs_prod.factor_names
         )
@@ -316,14 +318,14 @@ def sample_cost_model(nsims):
         # Sample deployment model factors
         nfactors = np.min([specs_dep.shape[0], specs_prod.shape[0]]) - 2
         N, K = get_NK(nsims, nfactors, calc_second_order=False)
-        sp_dep.sample_sobol(N, calc_second_order=False, skip_values=N)
+        sp_dep.sample_sobol(N, calc_second_order=False, skip_values=N, seed=seed)
         factors_df_dep = pd.DataFrame(
             data=sp_dep.samples, columns=specs_dep.factor_names
         )
 
         # Sample LM model factors
         N, K = get_NK(nsims, specs_lm.shape[0], calc_second_order=False)
-        sp_lm.sample_sobol(N, calc_second_order=False, skip_values=N)
+        sp_lm.sample_sobol(N, calc_second_order=False, skip_values=N, seed=seed)
         factors_df_lm = pd.DataFrame(data=sp_lm.samples, columns=specs_lm.factor_names)
 
         # Subset to just the number of sims as the scenarios beyond `nsims` do not get used
@@ -1155,6 +1157,7 @@ def calculate_costs(
     active_models: set = None,
     sample_scale: bool = False,
     session_reset_interval: int = _RESET_INTERVAL,
+    seed: int = None,
 ):
     """
     Sample costs for a set of interventions specified in ID_key, sampling nsims.
@@ -1189,7 +1192,14 @@ def calculate_costs(
     session_reset_interval : int, optional
         Recycle the process-local Excel session every N calls to bound memory
         growth.  Defaults to ``_RESET_INTERVAL`` (50).
+    seed : int, optional
+        Random seed for reproducibility.
     """
+    if seed is not None:
+        worker_seed = seed + p_iter_id
+    else:
+        worker_seed = None
+
     if active_models is None:
         active_models = {"outplant", "lm"}
     iv_keys_dir = stores.intervention_keys_dir
@@ -1271,7 +1281,9 @@ def calculate_costs(
 
                 cost_df = initialize_cost_df(all_sim_years, nsims)
 
-                # Sample cost model parameters once per rep — fixed across years
+                # Sample cost model parameters once per rep — fixed across years.
+                # Incorporate rep ID into seed so different reps get different draws.
+                _rep_seed = worker_seed + int(rep) if worker_seed is not None else None
                 (
                     prod_spec,
                     prod_factors,
@@ -1279,7 +1291,7 @@ def calculate_costs(
                     deploy_factors,
                     lm_spec,
                     lm_factors,
-                ) = sample_cost_model(nsims)
+                ) = sample_cost_model(nsims, seed=_rep_seed)
 
                 # In normal mode, apply the actual port distance to deploy_factors so
                 # the CSV reflects the value used in the simulation, not the config

--- a/cost_eco_model_linker/process_RME_data.py
+++ b/cost_eco_model_linker/process_RME_data.py
@@ -338,6 +338,7 @@ def create_economics_metric_files(
     economics_spatial_filepath=None,
     costs_only=False,
     distance_override_NM: float = None,
+    seed: int = None,
 ) -> tuple[str, list[str]]:
     """
     Main function for creating metric file summaries for input to economics modelling.
@@ -366,6 +367,8 @@ def create_economics_metric_files(
         When set, replaces the geographic port-distance calculation for all reefsets with
         this fixed value (in nautical miles). Use this for best-guess explorer runs where
         the config best-point distance should take precedence over computed reef distances.
+    seed : int, optional
+        Random seed for reproducibility.
 
     Returns
     -------
@@ -496,97 +499,15 @@ def create_economics_metric_files(
                 path_join(stores.cost_dir, "sim_template.parq"), index=False
             )
 
-        # Setup storage for ecological sample IDs
-        store_ecol_ids = np.zeros((nsims, len(intervention_ids)), dtype=int)
-
-        # Generate batch indices
-        if nsims != nbatches:
-            nmembers = int(np.ceil(nsims / nbatches))
-            batch_chunks = list(batched(range(nsims), nmembers))
-        else:
-            batch_chunks = [
-                list(range(nsims)),
-            ]
-
-        # Setup filenames for outputs
-        ecol_uncert = uncertainty_dict["ecol_uncert"]
-        expert_uncert = uncertainty_dict["expert_uncert"]
-        base_met_filename = f"_uncertainty_ecol{ecol_uncert}_indicator{expert_uncert}_var_"
-
-        run_id = os.path.basename(rme_files_path) + "_run"
-        id_filename = path_join(
-            stores.intervention_keys_dir, f"intervention_ID_key_{run_id}"
-        )
-        ecol_id_filename = path_join(
-            stores.intervention_keys_dir, f"intervention_rep_idx_{run_id}"
-        )
-
-        # Storage for results
-        metric_filepaths = []
-        id_key_dfs = []
-
-        # Process each intervention
-        for iv_idx, iv_id in enumerate(intervention_ids):
-            # Filter scenarios for this intervention
-            scens_df_iv = scens_df[scens_df["intervention id"] == iv_id].copy()
-            n_reps = scens_df_iv["rep"].max()
-
-            # Get intervention reefs
-            reefset_names = scens_df_iv["reefset"].unique()
-            iv_reefs = sum([iv_dict[reefset_name] for reefset_name in reefset_names], [])
-
-            # Calculate relative year (0 on first intervention year)
-            intervention_start = scens_df_iv["year"].min()
-            intervention_start_idx = np.where(years == intervention_start)[0][0]
-            data_store = base_data_store.copy()
-            data_store["year_relative"] = data_store["year_absolute"] - intervention_start
-
-            # Get scenario indices for this intervention and its counterfactual
-            scen_id_start = iv_idx * n_reps
-            scen_id_end = scen_id_start + n_reps
-            iv_scens = unique_iv_scens[scen_id_start:scen_id_end]
-
-            if "counterfactual_mapping" in iv_dict:
-                # Map intervention scenarios to counterfactuals using the provided mapping
-                cf_scens = np.array(iv_dict["counterfactual_mapping"])[iv_scens] - 1
-            else:
-                cf_scens = unique_cf_scens[scen_id_start:scen_id_end]
-
-            # Create intervention key dataframe
-            scen_cols = [
-                "intervention id",
-                "year",
-                "rep",
-                "number of corals",
-                "type",
-                "reefset",
-            ]
-            id_key_df = scens_df_iv[scen_cols].assign(port_name="", distance_to_port_NM=0.0, reef="")
-
-            # Determine distance to nearest port and representative reef per reefset
-            for rs_name in reefset_names:
-                rs_reefs = iv_dict[rs_name]
-                rs_port_name, rs_distance_NM = find_representative_port(
-                    reef_spatial_data, rs_reefs
-                )
-                rs_reef_name = find_representative_reef(reef_spatial_data, rs_reefs)
-                rs_mask = id_key_df["reefset"] == rs_name
-                id_key_df.loc[rs_mask, "port_name"] = rs_port_name
-                id_key_df.loc[rs_mask, "reef"] = rs_reef_name
-                id_key_df.loc[rs_mask, "distance_to_port_NM"] = (
-                    distance_override_NM if distance_override_NM is not None else rs_distance_NM
-                )
-
-            # Process batches
-            batch_files = []
-
-            # Shared template for all simulations
-            data_store.to_parquet(
-                path_join(stores.cost_dir, "sim_template.parq"), index=False
-            )
-
             for batch_idx, batch_sel in enumerate(batch_chunks):
                 ds = pd.DataFrame()
+
+                # Derive unique seed per batch and intervention for reproducibility.
+                _batch_seed = (
+                    seed + iv_idx * len(batch_chunks) + batch_idx
+                    if seed is not None
+                    else None
+                )
 
                 # Extract metrics for intervention and counterfactual
                 (
@@ -608,6 +529,7 @@ def create_economics_metric_files(
                     iv_scens,
                     uncertainty_dict=uncertainty_dict,
                     juv_max_years=[0, int(intervention_start_idx - 1)],
+                    seed=_batch_seed,
                 )
 
                 indicator_params_dict = {

--- a/cost_eco_model_linker/runner.py
+++ b/cost_eco_model_linker/runner.py
@@ -124,6 +124,7 @@ def evaluate(
     sample_scale: bool = False,
     distance_override_NM: float = None,
     coral_only: bool = False,
+    seed: int = None,
 ) -> list[str]:
     """
     Evaluate costs of intervention scenarios.
@@ -164,6 +165,8 @@ def evaluate(
         54 NM Centre) should be used instead of the computed reef distance.
     coral_only : bool, default=False
         If True, only use coral-related metrics (RCI_3 and RFI), excluding COTS and Rubble.
+    seed : int, optional
+        Random seed for reproducibility.
 
     Returns
     -------
@@ -248,6 +251,7 @@ def evaluate(
             distance_override_NM=distance_override_NM,
             uncertainty_dict=uncertainty_dict,
             costs_only=costs_only,
+            seed=seed,
         )
         from tqdm import tqdm
 
@@ -271,6 +275,7 @@ def evaluate(
             0.25,  # cont_p
             active_models=active_models,
             sample_scale=sample_scale,
+            seed=seed,
         )
         with mp.Pool(nprocs, initializer=_pool_initializer) as pool:
             result = pool.map(wrapper, range(nprocs))
@@ -293,6 +298,7 @@ def evaluate(
             uncertainty_dict=uncertainty_dict,
             costs_only=costs_only,
             distance_override_NM=distance_override_NM,
+            seed=seed,
         )
         from tqdm import tqdm
 
@@ -313,6 +319,7 @@ def evaluate(
             lm_model_fn,
             active_models=active_models,
             sample_scale=sample_scale,
+            seed=seed,
         )
         scen_ids = [
             int(re.search(r"ID(\d+)_", os.path.basename(fp)).group(1))


### PR DESCRIPTION
  This PR introduces a seed parameter across the metric extraction and cost sampling to ensure deterministic results.

  Changes
   * Added seed parameter to evaluate(), calculate_costs(), sample_cost_model(), and indicator_params().
   * Implemented worker-specific seed in parallel mode

Merge after #49 
 