### PR TITLE
Add optional persistent workbook sessions.

### DIFF
--- a/cost_eco_model_linker/cost_calculations.py
+++ b/cost_eco_model_linker/cost_calculations.py
@@ -523,6 +523,7 @@ def _process_outplant_reefset(
     eia_template_prod,
     eia_template_deploy,
     sample_scale=False,
+    workbook_session=None,
 ):
     """Run spreadsheet models for one outplant reefset and accumulate results.
 
@@ -539,17 +540,31 @@ def _process_outplant_reefset(
         Running totals across reefsets; modified in-place.
     acc : _OverviewAccumulator
         Overview tracking arrays; modified in-place.
+    workbook_session : WorkbookSession, optional
+        A session object for caching and seeding optimization.
 
     Returns
     -------
     deploy_wb, prod_wb, deploy_factors, prod_factors, eia_template_prod, eia_template_deploy
     """
-    prod_factors, deploy_factors = update_factors(prod_factors, deploy_factors, rs_spec, sample_scale=sample_scale)
+    prod_factors, deploy_factors = update_factors(
+        prod_factors, deploy_factors, rs_spec, sample_scale=sample_scale
+    )
     deploy_wb, deploy_factors = collect_deployment_costs(
-        xlapp, deploy_wb, deploy_model_fp, deploy_factors, deploy_spec
+        xlapp,
+        deploy_wb,
+        deploy_model_fp,
+        deploy_factors,
+        deploy_spec,
+        workbook_session=workbook_session,
     )
     prod_wb, prod_factors = collect_production_costs(
-        xlapp, prod_wb, prod_model_fp, prod_factors, prod_spec
+        xlapp,
+        prod_wb,
+        prod_model_fp,
+        prod_factors,
+        prod_spec,
+        workbook_session=workbook_session,
     )
 
     # Capture raw values before the CAPEX comparison block
@@ -628,6 +643,7 @@ def _process_lm_reefset(
     yr_idx,
     eia_template_lm,
     sample_scale=False,
+    workbook_session=None,
 ):
     """Run the LM spreadsheet model for one reefset and accumulate results.
 
@@ -644,19 +660,23 @@ def _process_lm_reefset(
     sample_scale : bool, optional
         When ``True`` (cost exploration mode), the larval pool count is already
         sampled and the template coral counts are ignored.  Defaults to ``False``.
+    workbook_session : WorkbookSession, optional
+        A session object for caching and seeding optimization.
 
     Returns
     -------
     lm_wb, lm_factors, eia_template_lm
     """
-    lm_factors = update_lm_factors(lm_factors, rs_spec_corals, lm_pool_min, lm_pool_max, sample_scale=sample_scale)
-    lm_wb, lm_factors = collect_lm_costs(xlapp, lm_wb, lm_model_fp, lm_factors, lm_spec)
+    lm_factors = update_lm_factors(
+        lm_factors, rs_spec_corals, lm_pool_min, lm_pool_max, sample_scale=sample_scale
+    )
+    lm_wb, lm_factors = collect_lm_costs(
+        xlapp, lm_wb, lm_model_fp, lm_factors, lm_spec, workbook_session=workbook_session
+    )
 
     if sample_scale:
         # Per-draw distances sampled from deploy_factors; compute a per-draw multiplier.
-        opex_mult = np.array(
-            [lm_opex_distance_multiplier(d) for d in rs_distance]
-        )
+        opex_mult = np.array([lm_opex_distance_multiplier(d) for d in rs_distance])
     else:
         opex_mult = lm_opex_distance_multiplier(rs_distance)
 
@@ -787,7 +807,8 @@ def _build_overview_rows_and_update_costs(
                     "draw": draw_i + 1,
                     "year": int(iv_yr),
                     "num_devices": acc.num_devices[yr_idx, draw_i],
-                    "num_1yoec": acc.num_1yoec[yr_idx, draw_i] + acc.lm_num_1yoec[yr_idx, draw_i],
+                    "num_1yoec": acc.num_1yoec[yr_idx, draw_i]
+                    + acc.lm_num_1yoec[yr_idx, draw_i],
                     "num_larval_pool": acc.lm_num_larval_pool[yr_idx, draw_i],
                     "yield_per_pool": acc.lm_yield_per_pool[yr_idx, draw_i],
                     "production_capex": post_prod_capex,
@@ -987,6 +1008,7 @@ def calculate_costs(
     p_iter_id: int = 0,
     active_models: set = None,
     sample_scale: bool = False,
+    workbook_session=None,
 ):
     """
     Sample costs for a set of interventions specified in ID_key, sampling nsims.
@@ -1018,6 +1040,8 @@ def calculate_costs(
         for outplant, larval pool count for LM) is drawn from the Sobol samples
         rather than derived from the RME template coral counts.  Defaults to
         ``False``.
+    workbook_session : WorkbookSession, optional
+        A session object for caching and seeding optimization.
     """
     if active_models is None:
         active_models = {"outplant", "lm"}
@@ -1032,10 +1056,20 @@ def calculate_costs(
         path_join(iv_keys_dir, f"intervention_{iv_ID_key}_{run_id}.csv")
     )
 
-    tmp_dir = tempfile.mkdtemp(prefix="ceml_")
-    deploy_model_fp, prod_model_fp, lm_model_fp = _copy_workbooks(
-        tmp_dir, deploy_model_filepath, prod_model_filepath, lm_model_filepath, _iter_id
-    )
+    if workbook_session is None:
+        tmp_dir = tempfile.mkdtemp(prefix="ceml_")
+        deploy_model_fp, prod_model_fp, lm_model_fp = _copy_workbooks(
+            tmp_dir,
+            deploy_model_filepath,
+            prod_model_filepath,
+            lm_model_filepath,
+            _iter_id,
+        )
+    else:
+        # Use models from their original locations via the persistent session
+        deploy_model_fp = deploy_model_filepath + ".xlsx"
+        prod_model_fp = prod_model_filepath + ".xlsx"
+        lm_model_fp = lm_model_filepath + ".xlsx"
 
     # Read pool bounds once from config so update_lm_factors can clamp each year
     from .sampling import DEFAULT_LM_VER
@@ -1053,12 +1087,17 @@ def calculate_costs(
     unique_ids = np.unique(ID_key.ID)
     cost_filepaths = []
 
-    # Open all three workbooks in a single Excel application to avoid
-    # RPC_E_DISCONNECTED errors that occur when multiple DispatchEx instances
-    # run simultaneously and one disconnects the others.
-    xlapp, deploy_wb = open_excel(deploy_model_fp)
-    _, prod_wb = open_excel(prod_model_fp, xlapp)
-    _, lm_wb = open_excel(lm_model_fp, xlapp)
+    # Open all three workbooks
+    if workbook_session is None:
+        xlapp, deploy_wb = open_excel(deploy_model_fp)
+        _, prod_wb = open_excel(prod_model_fp, xlapp)
+        _, lm_wb = open_excel(lm_model_fp, xlapp)
+    else:
+        deploy_wb = workbook_session.open_workbook(deploy_model_fp)
+        prod_wb = workbook_session.open_workbook(prod_model_fp)
+        lm_wb = workbook_session.open_workbook(lm_model_fp)
+        xlapp = workbook_session.xlapp
+
     try:
         for scen_id in unique_ids:
             # Output EIA assessment for each intervention scenario
@@ -1198,6 +1237,7 @@ def calculate_costs(
                                     eia_template_prod,
                                     eia_template_deploy,
                                     sample_scale=sample_scale,
+                                    workbook_session=workbook_session,
                                 )
 
                             # Inventory/replacement model applied separately to production and
@@ -1259,6 +1299,7 @@ def calculate_costs(
                                         yr_idx,
                                         eia_template_lm,
                                         sample_scale=sample_scale,
+                                        workbook_session=workbook_session,
                                     )
                                 )
 
@@ -1288,7 +1329,11 @@ def calculate_costs(
                 rep_cost_dfs.append((rep, cost_df, overview_rows))
 
                 # Expand EIA templates from the single temporary ID to all draws in this rep
-                for template in [eia_template_prod, eia_template_deploy, eia_template_lm]:
+                for template in [
+                    eia_template_prod,
+                    eia_template_deploy,
+                    eia_template_lm,
+                ]:
                     if template.empty:
                         continue
                     mask = template.iteration == temp_it_id
@@ -1309,11 +1354,17 @@ def calculate_costs(
                     # Update template in-place (since they are passed around)
                     expanded = pd.concat(new_rows, ignore_index=True)
                     if template is eia_template_prod:
-                        eia_template_prod = pd.concat([template, expanded], ignore_index=True)
+                        eia_template_prod = pd.concat(
+                            [template, expanded], ignore_index=True
+                        )
                     elif template is eia_template_deploy:
-                        eia_template_deploy = pd.concat([template, expanded], ignore_index=True)
+                        eia_template_deploy = pd.concat(
+                            [template, expanded], ignore_index=True
+                        )
                     elif template is eia_template_lm:
-                        eia_template_lm = pd.concat([template, expanded], ignore_index=True)
+                        eia_template_lm = pd.concat(
+                            [template, expanded], ignore_index=True
+                        )
 
                 draw_offset += nsims
 
@@ -1345,10 +1396,14 @@ def calculate_costs(
 
             # EIA scaled outputs need a single multiplier per year; use the mean
             # across draws (in exploration mode draws have different distances).
-            _mult_rows = [r for r in all_overview_rows if r.get("lm_opex_multiplier", 0) != 0]
+            _mult_rows = [
+                r for r in all_overview_rows if r.get("lm_opex_multiplier", 0) != 0
+            ]
             if _mult_rows:
                 _mult_df = pd.DataFrame(_mult_rows)[["year", "lm_opex_multiplier"]]
-                lm_opex_mult_by_year = _mult_df.groupby("year")["lm_opex_multiplier"].mean().to_dict()
+                lm_opex_mult_by_year = (
+                    _mult_df.groupby("year")["lm_opex_multiplier"].mean().to_dict()
+                )
             else:
                 lm_opex_mult_by_year = {}
             _ov = (
@@ -1383,8 +1438,11 @@ def calculate_costs(
             )
 
     finally:
-        close_excel(xlapp, deploy_wb, quit_app=False)
-        close_excel(xlapp, prod_wb, quit_app=False)
-        close_excel(xlapp, lm_wb, quit_app=True)
+        if workbook_session is None:
+            close_excel(xlapp, deploy_wb, quit_app=False)
+            close_excel(xlapp, prod_wb, quit_app=False)
+            close_excel(xlapp, lm_wb, quit_app=True)
+            if os.path.exists(tmp_dir):
+                shutil.rmtree(tmp_dir)
 
     return cost_filepaths

--- a/cost_eco_model_linker/handlers/__init__.py
+++ b/cost_eco_model_linker/handlers/__init__.py
@@ -1,4 +1,4 @@
-from .excel_handlers import open_excel, close_excel, reset_workbook
+from .excel_handlers import open_excel, close_excel, reset_workbook, WorkbookSession
 from .spreadsheet_interface import (
     get_industry_codes,
     find_table,

--- a/cost_eco_model_linker/handlers/excel_handlers.py
+++ b/cost_eco_model_linker/handlers/excel_handlers.py
@@ -70,6 +70,69 @@ def reset_workbook(xlapp, wb, fp):
     return wb
 
 
+class WorkbookSession:
+    """
+    Manages a persistent Excel application instance and caches open workbooks.
+
+    This class ensures that only one Excel process is created per worker and
+    that workbooks are reused across evaluations, significantly reducing the
+    overhead of DispatchEx and Workbooks.Open calls.
+    """
+
+    def __init__(self):
+        self.xlapp = None
+        self.workbooks = {}  # path -> wb object
+        self.seeded = set()  # set of paths that have been seeded
+
+    def _get_xlapp(self):
+        if self.xlapp is None:
+            self.xlapp = w32client.DispatchEx("Excel.Application")
+            self.xlapp.Interactive = False
+            self.xlapp.Visible = False
+            self.xlapp.DisplayAlerts = False
+        return self.xlapp
+
+    def open_workbook(self, fp):
+        """Open a workbook or return a cached instance."""
+        fp = os.path.abspath(fp)
+        if fp in self.workbooks:
+            return self.workbooks[fp]
+
+        xlapp = self._get_xlapp()
+        wb = xlapp.Workbooks.Open(fp)
+
+        # Performance properties MUST be set AFTER opening a workbook
+        xlapp.ScreenUpdating = False
+        xlapp.Calculation = -4135  # xlManual
+
+        self.workbooks[fp] = wb
+        return wb
+
+    def is_seeded(self, fp):
+        """Check if a workbook has already been seeded with baseline factors."""
+        return os.path.abspath(fp) in self.seeded
+
+    def mark_seeded(self, fp):
+        """Mark a workbook as seeded."""
+        self.seeded.add(os.path.abspath(fp))
+
+    def cleanup(self):
+        """Close all workbooks and quit the Excel application."""
+        for wb in self.workbooks.values():
+            try:
+                wb.Close(SaveChanges=False)
+            except (pywintypes.com_error, AttributeError):
+                pass
+        if self.xlapp:
+            try:
+                self.xlapp.Quit()
+            except (pywintypes.com_error, AttributeError):
+                pass
+        self.workbooks = {}
+        self.xlapp = None
+        self.seeded = set()
+
+
 # TODO: Use objects to auto-handle state
 # class ExcelConn:
 #     """Excel file connection"""

--- a/cost_eco_model_linker/runner.py
+++ b/cost_eco_model_linker/runner.py
@@ -41,7 +41,7 @@ from .sampling import (
 import numpy as np
 import pandas as pd
 
-SEMVER_RE = re.compile(r"^(?:.*/)?(\d+\.\d+\.\d+)\b")
+SEMVER_RE = re.compile(r"^(?:.*[/\\])?(\d+\.\d+\.\d+)\b")
 
 _KNOWN_MODEL_TYPES = {
     "production": "prod",
@@ -125,6 +125,7 @@ def evaluate(
     nprocs: int = 1,
     costs_only: bool = False,
     sample_scale: bool = False,
+    workbook_session=None,
 ) -> list[str]:
     """
     Evaluate costs of intervention scenarios.
@@ -293,6 +294,7 @@ def evaluate(
             lm_model_fn,
             active_models=active_models,
             sample_scale=sample_scale,
+            workbook_session=workbook_session,
         )
         scen_ids = [
             int(re.search(r"ID(\d+)_", os.path.basename(fp)).group(1))

--- a/cost_eco_model_linker/sampling.py
+++ b/cost_eco_model_linker/sampling.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 import matplotlib.pyplot as plt
 
-from .handlers import open_excel, close_excel, reset_workbook
+from .handlers import open_excel, close_excel, reset_workbook, WorkbookSession
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_PROD_VER = "3.9.1"
@@ -387,7 +387,9 @@ def _com_retry(fn, retries=3, delay=2.0):
             time.sleep(delay * (attempt + 1))
 
 
-def _run_cost_model(xlapp, wb, wb_path, cost_factors, factor_spec, calculate_cost):
+def _run_cost_model(
+    xlapp, wb, wb_path, cost_factors, factor_spec, calculate_cost, workbook_session=None
+):
     """
     Run and collect results from a cost model.
 
@@ -407,6 +409,8 @@ def _run_cost_model(xlapp, wb, wb_path, cost_factors, factor_spec, calculate_cos
         Function to use to sample cost. One of:
         - "calculate_deployment_cost"
         - "calculate_production_cost"
+    workbook_session : WorkbookSession, optional
+        A session object for caching and seeding optimization.
 
     Returns
     -------
@@ -429,9 +433,14 @@ def _run_cost_model(xlapp, wb, wb_path, cost_factors, factor_spec, calculate_cos
         finally:
             wb.Application.Calculation = xlAutomatic
 
+    # Optimized: Seed once per chunk, or skip if already seeded in a persistent session.
+    if not (workbook_session and workbook_session.is_seeded(wb_path)):
+        _com_retry(lambda: _seed_workbook(wb))
+        if workbook_session:
+            workbook_session.mark_seeded(wb_path)
+
     total_cost = np.full((cost_factors.shape[0], 2), np.nan)
     for idx_n in range(len(total_cost)):
-        _com_retry(lambda: _seed_workbook(wb))
         row_params = cost_factors.iloc[idx_n, :]
         try:
             total_cost[idx_n, :] = _com_retry(
@@ -457,7 +466,9 @@ def _run_cost_model(xlapp, wb, wb_path, cost_factors, factor_spec, calculate_cos
     return wb, cost_factors
 
 
-def collect_production_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
+def collect_production_costs(
+    xlapp, wb, wb_path, cost_factors, factor_spec, workbook_session=None
+):
     """
     Run the production cost model.
 
@@ -473,6 +484,8 @@ def collect_production_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
         Dataframe of factors to input in the cost model
     factor_spec : dataframe
         Factor specification, as loaded from the config.csv
+    workbook_session : WorkbookSession, optional
+        A session object for caching and seeding optimization.
 
     Returns
     -------
@@ -482,11 +495,19 @@ def collect_production_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
         Updated sampled factor dataframe with costs added
     """
     return _run_cost_model(
-        xlapp, wb, wb_path, cost_factors, factor_spec, calculate_production_cost
+        xlapp,
+        wb,
+        wb_path,
+        cost_factors,
+        factor_spec,
+        calculate_production_cost,
+        workbook_session=workbook_session,
     )
 
 
-def collect_deployment_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
+def collect_deployment_costs(
+    xlapp, wb, wb_path, cost_factors, factor_spec, workbook_session=None
+):
     """
     Run the deployment cost model.
 
@@ -502,6 +523,8 @@ def collect_deployment_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
         Dataframe of factors to input in the cost model
     factor_spec : dataframe
         Factor specification, as loaded from the config.csv
+    workbook_session : WorkbookSession, optional
+        A session object for caching and seeding optimization.
 
     Returns
     -------
@@ -511,7 +534,13 @@ def collect_deployment_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
         Updated sampled factor dataframe with costs added
     """
     return _run_cost_model(
-        xlapp, wb, wb_path, cost_factors, factor_spec, calculate_deployment_cost
+        xlapp,
+        wb,
+        wb_path,
+        cost_factors,
+        factor_spec,
+        calculate_deployment_cost,
+        workbook_session=workbook_session,
     )
 
 
@@ -536,7 +565,9 @@ def calculate_lm_cost(wb, factor_spec, factors):
     return evaluate_spreadsheet(wb, factor_spec, factors)
 
 
-def collect_lm_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
+def collect_lm_costs(
+    xlapp, wb, wb_path, cost_factors, factor_spec, workbook_session=None
+):
     """
     Run the LM cost model.
 
@@ -552,6 +583,8 @@ def collect_lm_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
         Dataframe of factors to input in the cost model.
     factor_spec : DataFrame
         Factor specification, as loaded from the config CSV.
+    workbook_session : WorkbookSession, optional
+        A session object for caching and seeding optimization.
 
     Returns
     -------
@@ -561,7 +594,13 @@ def collect_lm_costs(xlapp, wb, wb_path, cost_factors, factor_spec):
         Updated sampled factor dataframe with costs added.
     """
     return _run_cost_model(
-        xlapp, wb, wb_path, cost_factors, factor_spec, calculate_lm_cost
+        xlapp,
+        wb,
+        wb_path,
+        cost_factors,
+        factor_spec,
+        calculate_lm_cost,
+        workbook_session=workbook_session,
     )
 
 


### PR DESCRIPTION
When creating customs scripts with parallelisation sometimes, users need to maintain a persistent excel session to prevent the opening and closing excel instances over and over again. 

For each worker create a `WorkbookSession` object, pass this object to the `evaluate` function. Maintains a dictionary of cost models already opened by that worker, (CA models, LM models etc.).

The `evaluate` function then uses already initialised excel processes for its calculations instead of creating a new one.

Roughly 3x speedup for the explore script.

Here is a [gist](https://gist.github.com/DanTanAtAims/ba642d5a2eeb6527f8994e7b6770d9e2) that uses this PR. The number of cores in the script will needed to be edited to however many is needed.