### PR TITLE
fix: resolve EIA scaling and parallel stability issues

### DIFF
--- a/cost_eco_model_linker/cost_calculations.py
+++ b/cost_eco_model_linker/cost_calculations.py
@@ -1062,6 +1062,17 @@ def _write_eia_outputs(
             / np.where(row_denom == 0, np.nan, row_denom)[:, None]
         )
         shares[numeric_cols] = shares[numeric_cols].fillna(0.0)
+
+        # group by year/iteration and average proportions across
+        # locations before scaling by the global CAPEX total.
+        shares = shares.groupby(["year", "iteration"])[numeric_cols].mean().reset_index()
+        for col in _meta_cols:
+            if col not in shares.columns:
+                # Fill static metadata from the first available row per year/iteration
+                shares[col] = shares.set_index(["year", "iteration"]).index.map(
+                    capex_rows.drop_duplicates(["year", "iteration"]).set_index(["year", "iteration"])[col]
+                )
+
         _total_last(shares).to_csv(
             path_join(cost_dir, f"EIA_proportional_ID{scen_id}_{label}{_pid}.csv"),
             index=False,

--- a/cost_eco_model_linker/runner.py
+++ b/cost_eco_model_linker/runner.py
@@ -389,7 +389,16 @@ def parallel_evaluate(
         sample_scale=False,
     )
     with mp.Pool(ncores, initializer=_pool_initializer) as pool:
-        result = pool.map(wrapper, range(ncores))
+        res = pool.map_async(wrapper, range(ncores))
+        # Use a polling loop to wait for results. On Windows, a blocking .get()
+        # ignores signals like Ctrl+C. polling allows the main thread to
+        # receive the interrupt.
+        while not res.ready():
+            try:
+                res.wait(timeout=1.0)
+            except Exception:
+                pass
+        result = res.get()
 
     post_process_costs(result, nsims)
 
@@ -441,7 +450,7 @@ def _combine_parallel_outputs(cost_dir, scen_ids, nprocs, nbatches_per_core):
                 index=False,
             )
 
-        # --- EIA: average numeric columns across all workers then write clean names ---
+        # --- EIA: concat all workers then write clean names ---
         for file_type in ["raw", "proportional", "scaled"]:
             for label in ["production", "deployment", "lm"]:
                 worker_fps = [
@@ -455,12 +464,7 @@ def _combine_parallel_outputs(cost_dir, scen_ids, nprocs, nbatches_per_core):
                     continue
 
                 dfs = [pd.read_csv(fp) for fp in present]
-                numeric_cols = [c for c in dfs[0].columns if c not in _meta_cols]
-                avg = sum(df[numeric_cols].fillna(0.0).to_numpy() for df in dfs) / len(
-                    dfs
-                )
-                combined_eia = dfs[0][_meta_cols].copy()
-                combined_eia[numeric_cols] = avg
+                combined_eia = pd.concat(dfs, ignore_index=True).sort_values(_meta_cols)
                 combined_eia.to_csv(
                     os.path.join(cost_dir, f"EIA_{file_type}_ID{scen_id}_{label}.csv"),
                     index=False,


### PR DESCRIPTION
## Description
This PR addresses two critical bugs in the EIA (Economic Impact Assessment) output logic and improves parallel execution stability on Windows.

### Fixes:
1. **EIA CAPEX Scaling Inflation**: 
   - **Issue**: The original code scaled industry shares by the global CAPEX total for every location row. In scenarios with $ locations, this inflated the reported total cost by a factor of $.
   - **Fix**: Proportions are now averaged across locations per (year, iteration) before scaling, ensuring the sum of the EIA file matches the actual project budget.

2. **Parallel EIA Data Loss**:
   - **Issue**: Worker results were being averaged during recombination, which collapsed the Monte Carlo distribution and caused data loss (e.g., 100 draws averaged into 50 rows).
   - **Fix**: Worker results are now concatenated, preserving the full set of uncertainty draws.

### Interrupt:
- **Ctrl+C**: Replaced blocking pool.map with map_async and a polling loop. This allows the main thread to remain responsive to interruption signals in the PowerShell environment.