### PR TITLE
Revert pr 50

### DIFF
--- a/cost_eco_model_linker/cost_calculations.py
+++ b/cost_eco_model_linker/cost_calculations.py
@@ -630,7 +630,7 @@ def _process_outplant_reefset(
     departure_port,
     rs_years,
     iv_yr,
-    it_id,
+    rep,
     nsims,
     yr_prod_capex,
     yr_deploy_capex,
@@ -709,10 +709,10 @@ def _process_outplant_reefset(
 
     min_rs_yr = rs_years[0]
     eia_template_prod = fill_EIA_info(
-        prod_wb, "CA_P", it_id, min_rs_yr, iv_yr, "Townsville", eia_template_prod
+        prod_wb, "CA_P", rep, min_rs_yr, iv_yr, "Townsville", eia_template_prod
     )
     eia_template_deploy = fill_EIA_info(
-        deploy_wb, "CA_D", it_id, min_rs_yr, iv_yr, departure_port, eia_template_deploy
+        deploy_wb, "CA_D", rep, min_rs_yr, iv_yr, departure_port, eia_template_deploy
     )
 
     # DEBUG HERE
@@ -754,7 +754,7 @@ def _process_lm_reefset(
     departure_port,
     rs_years,
     iv_yr,
-    it_id,
+    rep,
     nsims,
     acc,
     yr_idx,
@@ -815,7 +815,7 @@ def _process_lm_reefset(
     )
 
     eia_template_lm = fill_lm_EIA_info(
-        lm_wb, "LM", it_id, rs_years[0], iv_yr, departure_port, eia_template_lm
+        lm_wb, "LM", rep, rs_years[0], iv_yr, departure_port, eia_template_lm
     )
     lm_wb = reset_workbook(xlapp, lm_wb, lm_model_fp)
 
@@ -1113,21 +1113,17 @@ def _merge_rep_costs(rep_cost_dfs):
     combined : DataFrame
     all_overview_rows : list[dict]
     """
-    draw_offset = 0
     combined = None
     all_overview_rows = []
 
     for _, cost_df, overview_rows in rep_cost_dfs:
-        rep_draw_cols = [c for c in cost_df.columns if c.startswith("draw")]
-        for row in overview_rows:
-            row["draw"] += draw_offset
         all_overview_rows.extend(overview_rows)
+        rep_draw_cols = [c for c in cost_df.columns if c.startswith("draw")]
 
         rename_map = {
-            c: f"draw{draw_offset + i + 1}" for i, c in enumerate(rep_draw_cols)
+            c: f"draw{i + 1}" for i, c in enumerate(rep_draw_cols)
         }
         renamed = cost_df.rename(columns=rename_map)
-        draw_offset += len(rep_draw_cols)
         if combined is None:
             combined = renamed
         else:
@@ -1273,11 +1269,9 @@ def calculate_costs(
             unique_reps = np.unique(ID_key.rep[scen_idx])
 
             rep_cost_dfs = []
-            draw_offset = 0
 
             for rep in unique_reps:
                 rep_idx = scen_idx & (ID_key.rep == rep)
-                temp_it_id = f"TEMP_{rep}"
 
                 cost_df = initialize_cost_df(all_sim_years, nsims)
 
@@ -1392,7 +1386,7 @@ def calculate_costs(
                                     departure_port,
                                     reefset_years_map[rs],
                                     iv_yr,
-                                    temp_it_id,
+                                    rep,
                                     nsims,
                                     yr_prod_capex,
                                     yr_deploy_capex,
@@ -1455,7 +1449,7 @@ def calculate_costs(
                                     departure_port,
                                     reefset_years_map[rs],
                                     iv_yr,
-                                    temp_it_id,
+                                    rep,
                                     nsims,
                                     acc,
                                     yr_idx,
@@ -1488,44 +1482,6 @@ def calculate_costs(
                 )
 
                 rep_cost_dfs.append((rep, cost_df, overview_rows))
-
-                # Expand EIA templates from the single temporary ID to all draws in this rep
-                for template in [
-                    eia_template_prod,
-                    eia_template_deploy,
-                    eia_template_lm,
-                ]:
-                    if template.empty:
-                        continue
-                    mask = template.iteration == temp_it_id
-                    rows_to_expand = template[mask]
-                    if rows_to_expand.empty:
-                        continue
-
-                    # Remove the temporary rows
-                    template.drop(template.index[mask], inplace=True)
-
-                    # Add a row for each draw in the rep
-                    new_rows = []
-                    for draw_i in range(nsims):
-                        dup = rows_to_expand.copy()
-                        dup["iteration"] = draw_offset + draw_i + 1
-                        new_rows.append(dup)
-
-                    # Update template in-place (since they are passed around)
-                    expanded = pd.concat(new_rows, ignore_index=True)
-                    if template is eia_template_prod:
-                        eia_template_prod = pd.concat(
-                            [template, expanded], ignore_index=True
-                        )
-                    elif template is eia_template_deploy:
-                        eia_template_deploy = pd.concat(
-                            [template, expanded], ignore_index=True
-                        )
-                    elif template is eia_template_lm:
-                        eia_template_lm = pd.concat([template, expanded], ignore_index=True)
-
-                draw_offset += nsims
 
             combined, all_overview_rows = _merge_rep_costs(rep_cost_dfs)
 

--- a/cost_eco_model_linker/cost_calculations.py
+++ b/cost_eco_model_linker/cost_calculations.py
@@ -1521,11 +1521,15 @@ def calculate_costs(
                 )
             else:
                 lm_opex_mult_by_year = {}
+
+            _ov = pd.DataFrame(all_overview_rows)
+            rep_draw_pair = _ov[["rep_id", "draw"]].drop_duplicates().sort_values(["rep_id", "draw"]).reset_index(drop=True)
+            rep_draw_pair["iteration"] = rep_draw_pair.index + 1
             _ov = (
-                pd.DataFrame(all_overview_rows)
-                .rename(columns={"draw": "iteration"})
+                _ov.merge(rep_draw_pair, on=["rep_id", "draw"], how="left")
                 .set_index(["year", "iteration"])
             )
+
             model_totals = {
                 "production": {
                     "capex": _ov["production_capex"],

--- a/cost_eco_model_linker/cost_calculations.py
+++ b/cost_eco_model_linker/cost_calculations.py
@@ -1101,29 +1101,27 @@ def _write_eia_outputs(
         )
 
 
+
 def _merge_rep_costs(rep_cost_dfs):
-    """Merge per-rep cost dataframes, renumbering draws sequentially across reps.
+    """Merge per-rep cost dataframes with draw/rep paired column names."""
 
-    Parameters
-    ----------
-    rep_cost_dfs : list[(rep, cost_df, overview_rows)]
-
-    Returns
-    -------
-    combined : DataFrame
-    all_overview_rows : list[dict]
-    """
     combined = None
     all_overview_rows = []
+    rep_index = 0  # counts reps, NOT draws
 
     for _, cost_df, overview_rows in rep_cost_dfs:
+        rep_index += 1
         all_overview_rows.extend(overview_rows)
+
         rep_draw_cols = [c for c in cost_df.columns if c.startswith("draw")]
 
         rename_map = {
-            c: f"draw{i + 1}" for i, c in enumerate(rep_draw_cols)
+            c: f"draw{i + 1}_rep{rep_index}"
+            for i, c in enumerate(rep_draw_cols)
         }
+
         renamed = cost_df.rename(columns=rename_map)
+
         if combined is None:
             combined = renamed
         else:
@@ -1134,7 +1132,6 @@ def _merge_rep_costs(rep_cost_dfs):
             )
 
     return combined, all_overview_rows
-
 
 # ---------------------------------------------------------------------------
 # Main entry point

--- a/cost_eco_model_linker/parallel_cost_sampling.py
+++ b/cost_eco_model_linker/parallel_cost_sampling.py
@@ -142,27 +142,76 @@ def post_process_metrics(
         for fn in file_list:
             os.remove(path_join(cost_dir, fn))
 
+def get_draw_id(p_id, rep_id, draw_id, nsims, nreps, ndraws_per_worker):
+
+    return p_id * nsims + (rep_id - 1) * nreps + p_id * ndraws_per_worker + (draw_id - 1)
 
 def post_process_costs(result, nsims):
     """
-    Save cost samples run in parallel in a single file which is in the correct format for the economics modelling.
+    Combine parallel cost outputs into a single file per rep,
+    with draw numbering global across reps and processes.
 
-    Parameters
-    ----------
-    result : list
-        List of filenames for saved parallel cost data runs.
-    nsims : int
-        Total number of draws to sample cost models, should match ecological metrics sampling.
+    Global ordering:
+        rep0: proc0 → proc1 → ...
+        rep1: proc0 → proc1 → ...
     """
-    for iv_id in range(len(result[0])):
-        init_cost_df = pd.read_csv(result[0][iv_id])
+
+    n_procs = len(result)
+    n_reps = len(result[0])
+
+    ndraws_per_worker = math.ceil(nsims / n_procs)
+
+    global_draw = 0  # NEVER resets
+
+    for iv_id in range(n_reps):
+
+        # Reference frame
+        base_df = pd.read_csv(result[0][iv_id])
         save_fn = result[0][iv_id].split("id")[0][:-6] + ".csv"
 
-        chunks = [init_cost_df[["year", "component"]]]
-        for res in result:
-            cost_temp = pd.read_csv(res[iv_id])
-            chunks.append(cost_temp[cost_temp.columns[2:]])  # column id 2 is where data begins
-            os.remove(res[iv_id])
+        base_cols = base_df[["year", "component"]]
+        chunks = [base_cols]
 
-        cost_df = pd.concat(chunks, axis=1)
-        cost_df.to_csv(save_fn, index=False)
+        draws_in_rep = 0
+
+        for proc_id in range(n_procs):
+            fn = result[proc_id][iv_id]
+            df = pd.read_csv(fn)
+
+            # Enforce identical rows
+            if not df[["year", "component"]].equals(base_cols):
+                raise ValueError(
+                    f"Row mismatch in proc {proc_id}, rep {iv_id}"
+                )
+
+            draw_df = df.iloc[:, 2:]
+            cols = draw_df.columns
+            nreps = len(cols) / nsims
+            extracted = cols.str.extract(r"draw(\d+)_rep(\d+)").astype(int)
+
+            # convert to lists
+            draws = extracted[0].tolist()
+            reps  = extracted[1].tolist()
+            draw_names = [f"draw{get_draw_id(
+                proc_id, r, d, nsims, nreps, ndraws_per_worker
+            )}" for (d, r) in zip(draws, reps)]
+
+            n_local = draw_df.shape[1]
+
+            draw_df = draw_df.copy()
+            draw_df.columns = draw_names
+
+            global_draw += n_local
+            draws_in_rep += n_local
+            chunks.append(draw_df)
+
+            os.remove(fn)
+
+        # Rep‑level validation
+        if draws_in_rep != nsims:
+            raise ValueError(
+                f"Rep {iv_id}: expected {nsims} draws, got {draws_in_rep}"
+            )
+
+        out_df = pd.concat(chunks, axis=1)
+        out_df.to_csv(save_fn, index=False)

--- a/cost_eco_model_linker/parallel_cost_sampling.py
+++ b/cost_eco_model_linker/parallel_cost_sampling.py
@@ -142,9 +142,9 @@ def post_process_metrics(
         for fn in file_list:
             os.remove(path_join(cost_dir, fn))
 
-def get_draw_id(p_id, rep_id, draw_id, nsims, nreps, ndraws_per_worker):
+def get_draw_id(p_id, rep_id, draw_id, nsims, ndraws_per_worker):
 
-    return int(p_id * nsims + (rep_id - 1) * nreps + p_id * ndraws_per_worker + (draw_id -1))
+    return int((rep_id - 1) * nsims + p_id * ndraws_per_worker + (draw_id))
 
 def post_process_costs(result, nsims):
     """
@@ -157,13 +157,13 @@ def post_process_costs(result, nsims):
     """
 
     n_procs = len(result)
-    n_reps = len(result[0])
+    n_iv = len(result[0])
 
     ndraws_per_worker = math.ceil(nsims / n_procs)
 
     global_draw = 0  # NEVER resets
 
-    for iv_id in range(n_reps):
+    for iv_id in range(n_iv):
 
         # Reference frame
         base_df = pd.read_csv(result[0][iv_id])
@@ -186,14 +186,13 @@ def post_process_costs(result, nsims):
 
             draw_df = df.iloc[:, 2:]
             cols = draw_df.columns
-            nreps = len(cols) / nsims
             extracted = cols.str.extract(r"draw(\d+)_rep(\d+)").astype(int)
 
             # convert to lists
             draws = extracted[0].tolist()
             reps  = extracted[1].tolist()
             draw_names = [f"draw{get_draw_id(
-                proc_id, r, d, nsims, nreps, ndraws_per_worker
+                proc_id, r, d, nsims, ndraws_per_worker
             )}" for (d, r) in zip(draws, reps)]
 
             n_local = draw_df.shape[1]
@@ -208,4 +207,20 @@ def post_process_costs(result, nsims):
             os.remove(fn)
 
         out_df = pd.concat(chunks, axis=1)
+
+        fixed_cols = ["year", "component"]
+
+        draw_cols = (
+            out_df
+            .columns
+            .drop(fixed_cols)
+            .to_series()
+            .str.extract(r"draw(\d+)")
+            .astype(int)[0]
+            .sort_values()
+        )
+
+        ordered_cols = fixed_cols + [f"draw{i}" for i in draw_cols]
+
+        out_df = out_df[ordered_cols]
         out_df.to_csv(save_fn, index=False)

--- a/cost_eco_model_linker/parallel_cost_sampling.py
+++ b/cost_eco_model_linker/parallel_cost_sampling.py
@@ -144,7 +144,7 @@ def post_process_metrics(
 
 def get_draw_id(p_id, rep_id, draw_id, nsims, nreps, ndraws_per_worker):
 
-    return p_id * nsims + (rep_id - 1) * nreps + p_id * ndraws_per_worker + (draw_id - 1)
+    return int(p_id * nsims + (rep_id - 1) * nreps + p_id * ndraws_per_worker + (draw_id -1))
 
 def post_process_costs(result, nsims):
     """
@@ -206,12 +206,6 @@ def post_process_costs(result, nsims):
             chunks.append(draw_df)
 
             os.remove(fn)
-
-        # Rep‑level validation
-        if draws_in_rep != nsims:
-            raise ValueError(
-                f"Rep {iv_id}: expected {nsims} draws, got {draws_in_rep}"
-            )
 
         out_df = pd.concat(chunks, axis=1)
         out_df.to_csv(save_fn, index=False)

--- a/cost_eco_model_linker/runner.py
+++ b/cost_eco_model_linker/runner.py
@@ -173,6 +173,11 @@ def evaluate(
     list[str]
         Paths to result files.
     """
+    if nsims % nprocs != 0:
+        raise ValueError(
+            f"nsims ({nsims}) must be exactly divisible by nprocs ({nprocs})"
+        )
+
     # On Windows, multiprocessing's spawn start method re-imports __main__ in
     # each worker during bootstrap. If the user calls evaluate() at the top
     # level of their script without a __name__ == '__main__' guard, this

--- a/cost_eco_model_linker/runner.py
+++ b/cost_eco_model_linker/runner.py
@@ -321,10 +321,12 @@ def evaluate(
             sample_scale=sample_scale,
             seed=seed,
         )
+        post_process_costs([result_paths], nsims)
         scen_ids = [
             int(re.search(r"ID(\d+)_", os.path.basename(fp)).group(1))
             for fp in result_paths
         ]
+
         _combine_parallel_outputs(
             stores.cost_dir, scen_ids, nprocs=1, nbatches_per_core=nsims
         )


### PR DESCRIPTION
Changes

- During parallel loop worker save CBA_cost_scaling.csv column names as `draw<i>_rep<j>.csv`
- During the post processing these columns are collected and renamed to draw<1-nsims> for rep 1 then draw<nsims+1 - 2*nsims> and so on, pandas hates duplicate column names

- The draw column in cost overview is fixed and simply records draws 1 - nsims as expected

- Resolved the non-unique multiindex bug by make intervation be uniquely based on rep, draw pairs so now eia saves as normal.
