### PR TITLE
feat: implement coral-only Reef Tourism Index (RTI_3)

### DIFF
--- a/cost_eco_model_linker/calculate_metrics.py
+++ b/cost_eco_model_linker/calculate_metrics.py
@@ -46,6 +46,7 @@ def default_uncertainty_dict() -> dict:
         "expert_uncert": 1,
         "rti_uncert": 1,
         "rfi_uncert": 1,
+        "coral_only": 0,
     }
 
 
@@ -228,6 +229,11 @@ def indicator_params(
     slope1 = 0.007476  # slope of coral cover to structural complexity equation
     slope2 = 1883.3  # slope of shelter volume to reef fish biomass
 
+    ## RTI_3 LINEAR REGRESSION UNCERTAINTY
+    rti_3_intercept_u = 0
+    if uncertainty_dict["rti_uncert"] != 0:
+        rti_3_intercept_u = np.random.normal(0, 0.163)
+
     return (
         max_coral_juv,
         sheltervolume_parameters,
@@ -238,6 +244,7 @@ def indicator_params(
         rti_juv_slope,
         rti_cots_slope,
         rti_rubble_slope,
+        rti_3_intercept_u,
         intercept1,
         intercept2,
         slope1,
@@ -277,6 +284,14 @@ def load_indicator_data(results_data, scen_ids, nsims, ecol_uncert, curr_eco_sim
         "relative_shelter_volume": _load("relative_shelter_volume"),
     }
 
+    # Load evenness with fallback
+    if "evenness" in results_data.variables:
+        data["coral_evenness"] = _load("evenness")
+    elif "coral_evenness" in results_data.variables:
+        data["coral_evenness"] = _load("coral_evenness")
+    else:
+        data["coral_evenness"] = None
+
     # Load juveniles with fallback
     if "coral_juv_m2" in results_data.variables:
         data["coral_juv_m2"] = _load("coral_juv_m2")
@@ -301,6 +316,9 @@ def load_indicator_data(results_data, scen_ids, nsims, ecol_uncert, curr_eco_sim
         )
 
     # Ensure all have (nsims, nreefs, nyrs) shape
+    if data["coral_evenness"] is None:
+        data["coral_evenness"] = np.ones(data["total_cover"].shape)
+
     for key in data:
         if data[key].shape[0] == 1 and nsims > 1:
             data[key] = np.tile(data[key], (nsims, 1, 1))
@@ -442,7 +460,9 @@ def reef_condition_rme(
     return {
         "total_cover": total_cover,
         "shelter_volume": shelterVolume,
+        "relative_shelter_volume": relative_shelter_volume,
         "coraljuv_relative": coraljuv_relative,
+        "coral_evenness": data["coral_evenness"],
         "COTSrel_complementary": COTSrel_complementary,
         "rubble_complementary": rubble_complementary,
         "RCI": reefcondition,
@@ -473,6 +493,19 @@ def rti_rme(
     all_reeftourism[all_reeftourism < 0.1] = 0.1
 
     return all_reeftourism
+
+
+def rti_3_rme(ecol_indicators, rti_3_intercept_u):
+    # Calculate RTI_3, which is a substitute Reef Tourism Index using only coral-related metrics
+    intcp = 0.47947 + rti_3_intercept_u
+    rti_3 = (
+        intcp
+        + 0.12764 * ecol_indicators["total_cover"]
+        + 0.31946 * ecol_indicators["coral_evenness"]
+        + 0.11676 * ecol_indicators["relative_shelter_volume"]
+        - 0.0036065 * ecol_indicators["coraljuv_relative"]
+    )
+    return np.round(np.clip(rti_3, 0.1, 0.9), 2)
 
 
 def rfi_rme(total_cover, intercept1, slope1, intercept2, slope2):
@@ -583,6 +616,12 @@ def extract_metrics(
             sheltervolume_parameters,
             rci_crit,
             rti_intercept,
+            rti_cov_slope,
+            rti_shelt_slope,
+            rti_juv_slope,
+            rti_cots_slope,
+            rti_rubble_slope,
+            rti_3_intercept_u,
             intercept1,
             intercept2,
             slope1,
@@ -598,6 +637,7 @@ def extract_metrics(
         rti_juv_slope = indicator_param_dict["rti_juv_slope"]
         rti_cots_slope = indicator_param_dict["rti_cots_slope"]
         rti_rubble_slope = indicator_param_dict["rti_rubble_slope"]
+        rti_3_intercept_u = indicator_param_dict["rti_3_intercept_u"]
         intercept1 = indicator_param_dict["intercept1"]
         intercept2 = indicator_param_dict["intercept2"]
         slope1 = indicator_param_dict["slope1"]
@@ -636,6 +676,9 @@ def extract_metrics(
     ecol_indicators["RFI"] = rfi_rme(
         ecol_indicators["total_cover"], intercept1, slope1, intercept2, slope2
     )
+
+    if uncertainty_dict.get("coral_only", 0):
+        ecol_indicators["RTI_3"] = rti_3_rme(ecol_indicators, rti_3_intercept_u)
 
     # save_metrics = np.zeros((nsims, m, len(ecol_indicators)))
     # Extract outputs and convert to long-form format, then save

--- a/cost_eco_model_linker/parallel_cost_sampling.py
+++ b/cost_eco_model_linker/parallel_cost_sampling.py
@@ -47,13 +47,14 @@ def para_sample_econ(
 
     if metrics is None:
         if coral_only:
-            print("Using 3-metric RCI and excluding RTI (coral-only mode).")
-            metrics = [prd.rci_3, prd.rfi]
+            print("Using 3-metric RCI and RTI_3 (coral-only mode).")
+            metrics = [prd.rci_3, prd.raw_rti_3, prd.rfi]
         else:
             metrics = [prd.rci, prd.raw_rti, prd.rfi]
 
     if uncertainty_dict is None:
         uncertainty_dict = prd.default_uncertainty_dict()
+    uncertainty_dict["coral_only"] = 1 if coral_only else 0
 
     # Create metric datafiles for economics modelling and extract filename for intervention key
     # Files are created separately for each core (as a large number of runs can cause memory issues
@@ -106,8 +107,10 @@ def post_process_metrics(
     """
     _metric_dir_map = {
         "rci": stores.rci_dir,
+        "rci_3": stores.rci_dir,
         "rfi": stores.rfi_dir,
         "raw_rti": stores.rti_dir,
+        "raw_rti_3": stores.rti_dir,
     }
 
     cost_dir = stores.cost_dir

--- a/cost_eco_model_linker/parallel_cost_sampling.py
+++ b/cost_eco_model_linker/parallel_cost_sampling.py
@@ -48,7 +48,16 @@ def para_sample_econ(
     if metrics is None:
         if coral_only:
             print("Using 3-metric RCI and RTI_3 (coral-only mode).")
-            metrics = [prd.rci_3, prd.raw_rti_3, prd.rfi]
+
+            # Wrapper to use rci_3 logic but keep 'rci' name for filename mapping
+            def rci(metrics_dict, metrics_df):
+                return prd.rci_3(metrics_dict, metrics_df)
+
+            # Wrapper to use rti_3 logic but keep 'raw_rti' name for filename mapping
+            def raw_rti(metrics_dict, metrics_df):
+                return prd.raw_rti_3(metrics_dict, metrics_df)
+
+            metrics = [rci, raw_rti, prd.rfi]
         else:
             metrics = [prd.rci, prd.raw_rti, prd.rfi]
 

--- a/cost_eco_model_linker/process_RME_data.py
+++ b/cost_eco_model_linker/process_RME_data.py
@@ -243,6 +243,20 @@ def raw_reefcond_3(metrics_dict: dict, metrics_df: pd.DataFrame):
     return np.transpose(metrics_dict["RCI_3"], (1, 0))
 
 
+def raw_rti_3(metrics_dict: dict, metrics_df: pd.DataFrame):
+    """
+    Processes metrics dict into raw RTI_3 for table storage.
+
+    Parameters
+    ----------
+    metrics_dict : dict
+        Array containing key sampled metrics and the RTI_3
+    metrics_df : dataframe
+        Dataframe containing scenario summary dataframe
+    """
+    return np.transpose(metrics_dict["RTI_3"], (1, 0))
+
+
 def raw_rti(metrics_dict: dict, metrics_df: pd.DataFrame):
     """
     Processes metrics dict into raw RTI for table storage.
@@ -520,6 +534,7 @@ def create_economics_metric_files(
                     rti_juv_slope,
                     rti_cots_slope,
                     rti_rubble_slope,
+                    rti_3_intercept_u,
                     intercept1,
                     intercept2,
                     slope1,
@@ -542,6 +557,7 @@ def create_economics_metric_files(
                     "rti_juv_slope": rti_juv_slope,
                     "rti_cots_slope": rti_cots_slope,
                     "rti_rubble_slope": rti_rubble_slope,
+                    "rti_3_intercept_u": rti_3_intercept_u,
                     "intercept1": intercept1,
                     "intercept2": intercept2,
                     "slope1": slope1,

--- a/cost_eco_model_linker/runner.py
+++ b/cost_eco_model_linker/runner.py
@@ -235,7 +235,11 @@ def evaluate(
             def rci(metrics_dict, metrics_df):
                 return prd.rci_3(metrics_dict, metrics_df)
 
-            metrics = [rci, prd.raw_rti_3, prd.rfi]
+            # Wrapper to use rti_3 logic but keep 'raw_rti' name for filename mapping
+            def raw_rti(metrics_dict, metrics_df):
+                return prd.raw_rti_3(metrics_dict, metrics_df)
+
+            metrics = [rci, raw_rti, prd.rfi]
         else:
             metrics = [prd.rci, prd.raw_rti, prd.rfi]
 
@@ -363,7 +367,11 @@ def parallel_evaluate(
             def rci(metrics_dict, metrics_df):
                 return prd.rci_3(metrics_dict, metrics_df)
 
-            metrics = [rci, prd.raw_rti_3, prd.rfi]
+            # Wrapper to use rti_3 logic but keep 'raw_rti' name for filename mapping
+            def raw_rti(metrics_dict, metrics_df):
+                return prd.raw_rti_3(metrics_dict, metrics_df)
+
+            metrics = [rci, raw_rti, prd.rfi]
         else:
             metrics = [prd.rci, prd.raw_rti, prd.rfi]
 

--- a/cost_eco_model_linker/runner.py
+++ b/cost_eco_model_linker/runner.py
@@ -229,17 +229,19 @@ def evaluate(
     # Set defaults
     if metrics is None:
         if coral_only:
-            print("Using 3-metric RCI and excluding RTI (coral-only mode).")
+            print("Using 3-metric RCI and RTI_3 (coral-only mode).")
 
             # Wrapper to use rci_3 logic but keep 'rci' name for filename mapping
             def rci(metrics_dict, metrics_df):
                 return prd.rci_3(metrics_dict, metrics_df)
 
-            metrics = [rci, prd.rfi]
+            metrics = [rci, prd.raw_rti_3, prd.rfi]
         else:
             metrics = [prd.rci, prd.raw_rti, prd.rfi]
+
     if uncertainty_dict is None:
         uncertainty_dict = default_uncertainty_dict()
+    uncertainty_dict["coral_only"] = 1 if coral_only else 0
 
     if nprocs > 1:
         # Parallel path: split nsims across nprocs workers; each worker gets
@@ -355,11 +357,13 @@ def parallel_evaluate(
     # Set defaults
     if metrics is None:
         if coral_only:
+            print("Using 3-metric RCI and RTI_3 (coral-only mode).")
+
             # Wrapper to use rci_3 logic but keep 'rci' name for filename mapping
             def rci(metrics_dict, metrics_df):
                 return prd.rci_3(metrics_dict, metrics_df)
 
-            metrics = [rci, prd.rfi]
+            metrics = [rci, prd.raw_rti_3, prd.rfi]
         else:
             metrics = [prd.rci, prd.raw_rti, prd.rfi]
 


### PR DESCRIPTION
This PR implements the **Coral-Only Reef Tourism Index (RTI_3)**.

### Changes
*   **Metric Logic:** Implemented the `RTI_3` vectorized regression formula in `calculate_metrics.py`.
*   **Data Loading:** Updated the NetCDF loader to extract `evenness` and `relative_shelter_volume`.
*   **Pipeline Integration:** Added a `coral_only` flag to `evaluate()` and `parallel_evaluate()` which automatically swaps the default metrics to `RCI_3` and `RTI_3`.
*   **Filename Standardization:** When in `coral_only` mode, the results for `RTI_3` and `RCI_3` are saved under the standard `raw_rti` and `rci` filenames to ensure compatibility with downstream visualization and analysis tools.
*   **Bug Fixes:** Corrected a signature mismatch in `create_economics_metric_files` that previously caused unpacking errors during batch processing.

---

### Documentation: RTI_3 (Coral-Only Reef Tourism Index)

Implementation sourced from [ADRIA implementation](https://github.com/open-AIMS/ADRIA.jl/blob/9a5875e0e78d21ea454bc76c4f3c266ad494770f/src/metrics/reef_indices.jl#L135-L196) pre-ADRIAIndicators

#### 1. Regression Formula
The metric is calculated using the following linear regression:
$$RTI_3 = \text{intercept} + (0.12764 \times \text{cover}) + (0.31946 \times \text{evenness}) + (0.11676 \times \text{SV}_{raw}) - (0.0036065 \times \text{juv}_{rel})$$

*   **Intercept:** Base value of `0.47947`.
*   **Cover:** Total coral cover normalized (0.0 - 1.0).
*   **Evenness:** Loaded from NetCDF variable `evenness` (falls back to `coral_evenness` or `1.0`).
*   **SV (Raw):** Raw `relative_shelter_volume` from the ecological model (Note: Unlike the standard RTI, **no 9.33 scaling** is applied).
*   **Juv (Relative):** Juvenile density relative to the historical baseline.

#### 2. Uncertainty & Clamping
*   **Uncertainty Source:** If `rti_uncert` is enabled, Gaussian noise is added to the intercept using **$\sigma = 0.163$** derived from the original implementation. 
*   **Clamping:** Results are strictly bounded between `0.1` and `0.9`.

#### 3. Output Mapping
To maintain compatibility with existing post-processing scripts, the following mapping is used when `coral_only=True`:
*   `RCI_3` $\rightarrow$ Saved as `..._rci.parq`
*   `RTI_3` $\rightarrow$ Saved as `..._raw_rti.parq`
